### PR TITLE
Editor/dataset switching ui

### DIFF
--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -9,13 +9,13 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-<div>
+<div style="height: 100%;">
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3);">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowseruss-search">
     <input [(ngModel)]="path" placeholder="Enter a directory..." class="filebrowseruss-search-input" (change)="displayTree(path, false)">
     </div>
-    <div (click)="onClick($event);" [hidden]="hideExplorer">
+    <div (click)="onClick($event);" [hidden]="hideExplorer" style="height: 100%;">
         <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)" [style]="style"
         (contextmenu)="$event.preventDefault(); onRightClick($event);" 
         ></tree-root>

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -196,6 +196,22 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.renameClick.emit($event);
   }
 
+  sortFn(a: any, b: any) {
+    if (a.directory !== b.directory) {
+      if (a.directory === true) {
+        return -1;
+      } else {
+        return 1;
+      }
+    } else {
+      if (a.name.toLowerCase() < b.name.toLowerCase()) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+  }
+
   //Displays the starting file structure of 'path'
   private displayTree(path: string, update: boolean): void {
     if (path === undefined || path == '') {
@@ -204,7 +220,8 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.ussData = this.ussSrv.getFile(path); 
     this.ussData.subscribe(
     files => {
-    let tempChildren: TreeNode[] = [];
+      files.entries.sort(this.sortFn);
+      const tempChildren: TreeNode[] = [];
       for (let i: number = 0; i < files.entries.length; i++) {
         if (files.entries[i].directory) {
           files.entries[i].children = [];
@@ -236,46 +253,12 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
           if (indexArray[indexArray.length-1] == dataArray.length)
           {
             indexArray.pop();
-            
+
             if (parentNode !== undefined && parentNode.parent !== undefined)
               {
                 parentNode = parentNode.parent;
                 dataArray = parentNode.children;
                 networkArray = dataArray;
-
-                //TODO: Uncomment code to also update data of children, however this will cause
-                //a desync with the async code so you need to add code that waits for the .subscribe(...) method to finish
-                //because the loop cannot move onto a children when the parent data are not finished loading from
-                
-                // this.ussData = this.ussSrv.getFile(parentNode.path);
-                // let array: TreeNode[] = [];
-                // this.ussData.subscribe(
-                //   files => {
-                //     for (let i: number = 0; i < files.entries.length; i++) {
-                //       if (files.entries[i].directory) {
-                //         files.entries[i].children = [];
-                //         files.entries[i].data = "Folder";
-                //         files.entries[i].collapsedIcon = "fa fa-folder";
-                //         files.entries[i].expandedIcon = "fa fa-folder-open";
-                //       }
-                //       else {
-                //         files.entries[i].items = {};
-                //         files.entries[i].icon = "fa fa-file";
-                //         files.entries[i].data = "File";
-                //       }
-                //       files.entries[i].label = files.entries[i].name;
-                //       files.entries[i].id = i;
-                //       array.push(files.entries[i]);
-
-                //     } networkArray = array; },
-                //     error => this.log.debug("Error: ", error),
-                //    );
-                //    this.log.debug(array);
-                //    while (array.length == 0)
-                //    {
-                //      //setTimeout("sleep", 1000);
-                //    }
-
               }
               else{
                 if (parentNode !== undefined)
@@ -286,7 +269,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
                     }
                   }
                 }
-                
+
                 dataArray = this.data;
                 networkArray = tempChildren;
               }
@@ -297,40 +280,6 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
             parentNode = dataArray[indexArray[indexArray.length-1]];
             dataArray = parentNode.children;
             networkArray = dataArray;
-
-            //TODO: Uncomment code to also update data of children, however this will cause
-            //a desync with the async code so you need to add code that waits for the .subscribe(...) method to finish
-            // this.ussData = this.ussSrv.getFile(parentNode.path);
-            // let array: TreeNode[] = [];
-            // this.ussData.subscribe(
-            //   files => {
-                
-            //     for (let i: number = 0; i < files.entries.length; i++) {
-            //       if (files.entries[i].directory) {
-            //         files.entries[i].children = [];
-            //         files.entries[i].data = "Folder";
-            //         files.entries[i].collapsedIcon = "fa fa-folder";
-            //         files.entries[i].expandedIcon = "fa fa-folder-open";
-            //       }
-            //       else {
-            //         files.entries[i].items = {};
-            //         files.entries[i].icon = "fa fa-file";
-            //         files.entries[i].data = "File";
-            //       }
-            //       files.entries[i].label = files.entries[i].name;
-            //       files.entries[i].id = i;
-            //       array.push(files.entries[i]);
-
-            //     } networkArray = array; },
-            //     error => this.log.debug("Error: ", error), );
-                
-            //     this.log.debug(array);
-            //     while (array.length == 0)
-            //       {
-            //         //setTimeout("sleep", 1000);
-            //         //createAwait()
-            //       }
-            
             indexArray[indexArray.length-1]++;
             indexArray.push(0);
           }
@@ -343,7 +292,8 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
       }
 
       this.log.debug("Tree has been updated.");
-      this.data = tempChildren;  
+      this.log.debug(tempChildren);
+      this.data = tempChildren;
       this.path = path;
 
       this.persistanceDataService.getData()
@@ -354,7 +304,6 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
               this.persistanceDataService.setData(this.dataObject)
                 .subscribe((res: any) => { });
             })
-
         },
         error => this.errorMessage = <any>error
       );
@@ -384,6 +333,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
       let tempChildren: TreeNode[] = [];
       this.ussData.subscribe(
         files => {
+          files.entries.sort(this.sortFn);
           //TODO: Could be turned into a util service...
           for (let i: number = 0; i < files.entries.length; i++) {
             if (files.entries[i].directory) {
@@ -401,7 +351,8 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
             files.entries[i].id = i;
             tempChildren.push(files.entries[i]);
 
-          } $event.node.children = tempChildren;
+          }
+          $event.node.children = tempChildren;
           $event.node.expandedIcon = "fa fa-folder-open"; $event.node.collapsedIcon = "fa fa-folder";
           this.log.debug(path + " was populated with " + tempChildren.length + " children.");
 

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -20,6 +20,7 @@
 
 .ui-tree {
   width: 100%;
+  height: 100%;
   min-width: 300px;
   background: transparent;
   border: 0px;
@@ -29,6 +30,8 @@
   padding: 15px;
   font-size: medium;
   color: white;
+  overflow: auto;
+  height: 100%;
 }
 
 .ui-tree .ui-widget .ui-widget-content {

--- a/src/app/components/zlux-file-explorer/zlux-file-explorer.component.css
+++ b/src/app/components/zlux-file-explorer/zlux-file-explorer.component.css
@@ -13,10 +13,11 @@
 .fileexplorer-browser-module{
   margin-left: 10px;
   margin-top: 10px;
+  height: 100%;
 }
 
 .fileexplorer-global{
-  /* padding: 10px; */
+  height: 100%;
 }
 
 .fileexplorer-tabs{


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20528015/58448215-2e9de580-80d5-11e9-8c38-c3934e537eb9.png)

Makes it so that the tabs are always visible (and don't get hidden with large amounts of data present so the user doesn't have to scroll back up)

**PART 2 of 2** https://github.com/zowe/zlux-editor/pull/51