### PR TITLE
Add mvs uss search history

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -13,7 +13,11 @@
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowsermvs-search">
-      <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
+      <input [(ngModel)]="path" list="searchMVSHistory" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
+      <!-- TODO: make search history a directive to use in both uss and mvs-->
+      <datalist id="searchMVSHistory">
+        <option *ngFor="let item of mvsSearchHistory.searchHistoryVal" [value]="item"></option>
+      </datalist>
     </div>
     <div [hidden]="hideExplorer" style="height: 100%;">
         <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)"

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -18,10 +18,11 @@ import { take } from 'rxjs/operators';
 import { FileService } from '../../services/file.service';
 import { ProjectStructure, RecordFormat, DatasetOrganization, DatasetAttributes } from '../../structures/editor-project';
 import { childEvent } from '../../structures/child-event';
-// import { PersistentDataService } from '../../services/persistentData.service';
+//import { PersistentDataService } from '../../services/persistentData.service';
 import { MvsDataObject } from '../../structures/persistantdata';
 import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import { TreeNode } from 'primeng/primeng';
+import { SearchHistoryService } from '../../services/searchHistoryService';
 
 /*import {FileBrowserFileSelectedEvent,
   IFileBrowserMVS
@@ -35,7 +36,7 @@ import {Capability, FileBrowserCapabilities} from '../../../../../../zlux-platfo
   templateUrl: './filebrowsermvs.component.html',
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./filebrowsermvs.component.css'],
-  providers: [FileService/*, PersistentDataService*/]
+  providers: [FileService, /*PersistentDataService,*/ SearchHistoryService ]
 })
 export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowserMVS,
   //componentClass:ComponentClass;
@@ -56,9 +57,11 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   constructor(private fileService: FileService, 
     private elementRef:ElementRef, 
     // private persistentDataService: PersistentDataService,
+    private mvsSearchHistory:SearchHistoryService,
     @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
     //this.componentClass = ComponentClass.FileBrowser;
     //this.initalizeCapabilities();
+    this.mvsSearchHistory.onInit('mvs');
     this.path = "";
     this.lastPath = "";
     this.rtClickDisplay = false;
@@ -152,6 +155,8 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.getTreeForQueryAsync(path).then((res) => {
       this.data = res;
     });
+    
+    this.refreshHistory(path);
   }
 
   getTreeForQueryAsync(path: string): Promise<any> {
@@ -232,6 +237,13 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
     }
   }
 
+  refreshHistory(path:string) {
+    const sub = this.mvsSearchHistory
+                  .saveSearchHistory(path)
+                  .subscribe(()=>{
+                    if(sub) sub.unsubscribe();
+                  });
+  }
 
 /**
 * [levelUp: function to ascend up a level in the file/folder tree]

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -13,7 +13,11 @@
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowseruss-search">
-        <input [(ngModel)]="path" placeholder="Enter a directory..." class="filebrowseruss-search-input" (change)="displayTree(path, false)" [disabled]="isLoading">
+      <input [(ngModel)]="path" list="searchUSSHistory" placeholder="Enter a directory..." class="filebrowseruss-search-input" (change)="displayTree(path, false)" [disabled]="isLoading">
+      <!-- TODO: make search history a directive to use in both uss and mvs-->
+      <datalist id="searchUSSHistory">
+        <option *ngFor="let item of ussSearchHistory.searchHistoryVal" [value]="item"></option>
+      </datalist>
     </div>
     <div class="fa fa-spinner fa-spin" [hidden]="!isLoading"></div>
     <div (click)="onClick($event);" [hidden]="hideExplorer" style="height: 100%;">
@@ -25,11 +29,11 @@
     </div>
 
 <!-- 
-This program and the accompanying materials are
-made available under the terms of the Eclipse Public License v2.0 which accompanies
-this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
-SPDX-License-Identifier: EPL-2.0
-
-Copyright Contributors to the Zowe Project.
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
 -->

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -25,11 +25,11 @@
     </div>
 
 <!-- 
-  This program and the accompanying materials are
-  made available under the terms of the Eclipse Public License v2.0 which accompanies
-  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
-  SPDX-License-Identifier: EPL-2.0
-  
-  Copyright Contributors to the Zowe Project.
+This program and the accompanying materials are
+made available under the terms of the Eclipse Public License v2.0 which accompanies
+this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
 -->

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -29,13 +29,14 @@ import { UssDataObject } from '../../structures/persistantdata';
 import { TreeNode } from 'primeng/primeng';
 import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import 'rxjs/add/operator/toPromise';
+import { SearchHistoryService } from '../../services/searchHistoryService';
 
 @Component({
   selector: 'file-browser-uss',
   templateUrl: './filebrowseruss.component.html',
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./filebrowseruss.component.css'],
-  providers: [UssCrudService/*, PersistentDataService*/]
+  providers: [UssCrudService, /*PersistentDataService,*/ SearchHistoryService]
 })
 
 export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowserUSS,
@@ -70,9 +71,12 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
     private ussSrv: UssCrudService,
     private utils: UtilsService, 
     /*private persistentDataService: PersistentDataService,*/
-    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger) {
+    private ussSearchHistory:SearchHistoryService,
+    @Inject(Angular2InjectionTokens.LOGGER) private log: ZLUX.ComponentLogger
+    ) {
     //this.componentClass = ComponentClass.FileBrowser;
     this.initalizeCapabilities();
+    this.ussSearchHistory.onInit('uss');
     this.rtClickDisplay = false;
     this.addFileDisplay = false;
     this.addFolderDisplay = false;
@@ -119,7 +123,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
     //     this.displayTree(this.root, false);
     //   })
       // this.intervalId = setInterval(() => {
-      //   this.updateUss(this.path);
+        this.updateUss(this.path);
       // }, this.timeVar);
   }
 
@@ -338,7 +342,16 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
         }
       );
 
+      this.refreshHistory(this.path);
     }
+
+  private refreshHistory(path:string) {
+    const sub = this.ussSearchHistory
+                  .saveSearchHistory(path)
+                  .subscribe(()=>{
+                    if(sub) sub.unsubscribe();
+                  });
+}
 
   public sleep(milliseconds) {
       var start = new Date().getTime();

--- a/src/app/services/file.service.ts
+++ b/src/app/services/file.service.ts
@@ -12,9 +12,10 @@
 
 import { Injectable } from '@angular/core';
 import { Http} from '@angular/http';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/throw';
 
 @Injectable()
 export class FileService {

--- a/src/app/services/searchHistoryService.ts
+++ b/src/app/services/searchHistoryService.ts
@@ -1,0 +1,96 @@
+import { Http, Headers, RequestOptions } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { Injectable, Inject } from '@angular/core';
+import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
+import { of } from 'rxjs';
+
+
+@Injectable()
+export class SearchHistoryService {
+  private scope: string = 'user';
+  private resourcePath: string = 'ui/history';
+  private basePlugin: ZLUX.Plugin;
+
+  private resourceName: string;
+  private uri: string;
+  public searchHistory: string[];
+  private initHistory:boolean; 
+  private type:string;
+
+  constructor(@Inject(Angular2InjectionTokens.PLUGIN_DEFINITION) private pluginDefinition: ZLUX.ContainerPluginDefinition
+  ,  private http: Http) {
+    
+  }
+
+  onInit(type:string) {
+    this.type = type;
+    this.basePlugin = this.pluginDefinition.getBasePlugin();
+    this.resourceName = `${type}Search.json`;
+    this.uri = ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.basePlugin, this.scope, this.resourcePath, this.resourceName);
+    this.searchHistory = [];
+    this.getData();
+  }
+
+  private getData(): void {
+
+    let headers = new Headers({ 'Content-Type': 'application/json' });
+    let options = new RequestOptions({ headers: headers });
+
+    const getRequest =  this.http
+      .get(this.uri, options)
+      .map(res => res.json())
+      .catch((err => {
+          let type = this.type;
+          console.log(err);
+          return null;
+      }));
+
+      const sub = getRequest.subscribe((data) => {
+        if (data && data.contents && data.contents.history) {
+          this.searchHistory = Array.from(new Set(this.searchHistory.concat(data.contents.history)));
+        };
+  
+        this.initHistory = true;
+        sub.unsubscribe();
+      });
+  }
+
+  private saveData(history: string[]): Observable<any> {
+
+    let headers = new Headers({ 'Content-Type': 'application/json' });
+    let options = new RequestOptions({ headers: headers });
+
+    let params = {
+        "history": history
+    };
+
+    return this.http
+      .put(this.uri, params, options)
+      .catch((err => {
+          let type = this.type;
+          console.log(`save${type}SearchHistory error`, err);
+          return null
+      }));
+  }
+
+  public saveSearchHistory(path: string):Observable<any> {
+    if (path && path.trim() != '' && !this.searchHistory.includes(path)) {
+      this.searchHistory.push(path);
+      if(this.initHistory) {
+        //setTimeout(()=> {
+        return this.saveData(this.searchHistory);
+        //}, 100); 
+      } 
+      else {
+        return of(this.searchHistory);
+      }
+    }
+
+    return of(this.searchHistory);
+  }
+
+  public get searchHistoryVal():string[] {
+     return this.searchHistory;
+  }
+
+}

--- a/src/app/services/uss.crud.service.ts
+++ b/src/app/services/uss.crud.service.ts
@@ -12,9 +12,10 @@
 
 import { Injectable   } from '@angular/core';
 import { Http } from '@angular/http';
+import { Observable   } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import { Observable   } from 'rxjs/Observable';
+import 'rxjs/add/observable/throw';
 import { UtilsService } from './utils.service'
 
 @Injectable()


### PR DESCRIPTION
added capability to store search history for mvs and uss, history will get stored in zlux-app-server\deploy\instance\users\<Username>\ZLUX\pluginStorage\org.zowe.editor\ui\history. 

It works in conjunction with modified pluginDefinition.json of zlux-editor, where we need to define configuration services.

previous commit of text transform is reverted