### PR TITLE
Fixed tree navigation to look right

### DIFF
--- a/webClient/src/app/components/tree/tree.component.css
+++ b/webClient/src/app/components/tree/tree.component.css
@@ -11,26 +11,65 @@
 
 .fileexplorer-tree-panel {
   flex: 1 1 0px;
-  overflow: auto;
-  background: #efefef;
-  min-height: 300px;
+  background: transparent;
   height: 100%;
   width: 100%;
-}
-
-.ui-tree-container {
-  padding: 10px
+  margin-right: 10px;
+  color: white;
 }
 
 .ui-tree {
-  width: 95%;
+  width: 100%;
+  height: 100%;
   min-width: 300px;
-  padding: 15px;
-  padding-bottom: 15px;
-  font-size: 16px;
+  background: transparent;
+  border: 0px;
 }
+
+.ui-tree .ui-tree-container {
+  padding: 15px;
+  font-size: medium;
+  color: white;
+  overflow: auto;
+  height: 100%;
+}
+
+.ui-tree .ui-widget .ui-widget-content {
+  background: transparent;
+  border: 0px;
+}
+
+.ui-treenode-label.ui-state-highlight {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.ui-tree .ui-treenode-label.ui-state-highlight {
+  color: black;
+}
+
 .ui-treenode {
   width: fit-content;
+  padding: 1px;
+}
+
+.ui-treenode-label {
+  padding-left: 3px;
+}
+
+.ui-treenode-icon {
+  padding-right: 3px;
+}
+
+.ui-tree-empty-message {
+  color: white;
+}
+
+.ui-tree .ui-treenode-children {
+  margin: 0;
+  padding: 0 0 0 1em;
 }
 
 


### PR DESCRIPTION
With the recent changes to zlux-app-manager (maybe related to the removal of Prime things) the tree in the Editor now longer has a tree cascade.

master of zlux-app-manager
![image](https://user-images.githubusercontent.com/20528015/60835880-3b146400-a192-11e9-9339-3afaacd59677.png)


staging of zlux-app-manager
![image](https://user-images.githubusercontent.com/20528015/60835894-44053580-a192-11e9-8c67-957d56856a17.png)

This PR adds CSS to return the UI back to normal.

