### PR TITLE
Fixed tree navigation to look right

### DIFF
--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -41,6 +41,9 @@
 
 .ui-treenode-label.ui-state-highlight {
   background-color: #e0e0e0;
+  border-radius: 5px;
+  padding-left: 5px;
+  padding-right: 5px;
 }
 
 .ui-tree .ui-treenode-label.ui-state-highlight {

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -41,7 +41,7 @@
 
 .ui-treenode-label.ui-state-highlight {
   background-color: #e0e0e0;
-  border-radius: 5px;
+  border-radius: 4px;
   padding-left: 5px;
   padding-right: 5px;
 }

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -49,10 +49,24 @@
 
 .ui-treenode {
   width: fit-content;
+  padding: 1px;
+}
+
+.ui-treenode-label {
+  padding-left: 3px;
+}
+
+.ui-treenode-icon {
+  padding-right: 3px;
 }
 
 .ui-tree-empty-message {
   color: white;
+}
+
+.ui-tree .ui-treenode-children {
+  margin: 0;
+  padding: 0 0 0 1em;
 }
 
 


### PR DESCRIPTION
With the recent changes to zlux-app-manager (maybe related to the removal of Prime things) the tree in the Editor now longer has a tree cascade.

master of zlux-app-manager

![image](https://user-images.githubusercontent.com/20528015/60836776-70ba4c80-a194-11e9-9d3c-b75a7b29fb0c.png)


staging of zlux-app-manager

![image](https://user-images.githubusercontent.com/20528015/60836778-744dd380-a194-11e9-9968-e26639dbfd79.png)


This PR adds CSS to return the UI back to normal.