### PR TITLE
Data set file explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,35 @@
         "tslib": "^1.9.0"
       }
     },
+    "@fortawesome/angular-fontawesome": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.2.1.tgz",
+      "integrity": "sha512-B77fIEjq9bgHGncx5sfFuANh6qow6+MLHbU6C7lMIdeLXykkWTWOiPk+CqlmPOYXIpUH1lNaVykgTSqAk65pIw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.19.tgz",
+      "integrity": "sha512-nd2Ul/CUs8U9sjofQYAALzOGpgkVJQgEhIJnOHaoyVR/LeC3x2mVg4eB910a4kS6WgLPebAY0M2fApEI497raQ=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.19.tgz",
+      "integrity": "sha512-D4ICXg9oU08eF9o7Or392gPpjmwwgJu8ecCFusthbID95CLVXOgIyd4mOKD9Nud5Ckz+Ty59pqkNtThDKR0erA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.19"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.9.0.tgz",
+      "integrity": "sha512-U8YXPfWcSozsCW0psCtlRGKjjRs5+Am5JJwLOUmVHFZbIEWzaz4YbP84EoPwUsVmSAKrisu3QeNcVOtmGml0Xw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.19"
+      }
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -1955,7 +1984,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1969,8 +1999,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -1985,7 +2015,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2052,7 +2082,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -2067,14 +2097,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.3"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -2083,12 +2113,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -2103,7 +2133,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -2112,7 +2142,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -2121,8 +2151,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -2143,7 +2173,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -2158,7 +2188,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2173,8 +2203,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -2183,7 +2213,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -2207,9 +2237,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.24",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2218,16 +2248,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.4",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.2.0",
-            "npmlog": "4.1.2",
-            "rc": "1.2.8",
-            "rimraf": "2.6.3",
-            "semver": "5.6.0",
-            "tar": "4.4.8"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -2236,8 +2266,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -2252,8 +2282,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.5"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2262,10 +2292,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.5",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -2286,7 +2316,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2307,8 +2337,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2329,10 +2359,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2349,13 +2379,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -2364,13 +2394,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2408,9 +2439,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2419,15 +2450,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2442,13 +2474,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.1.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.5",
-            "minizlib": "1.2.1",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -2463,18 +2495,20 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "@angular/http": "~6.0.9",
     "@angular/platform-browser": "~6.0.9",
     "@angular/router": "~6.0.9",
+    "@fortawesome/angular-fontawesome": "~0.2.1",
+    "@fortawesome/fontawesome-svg-core": "~1.2.19",
+    "@fortawesome/free-solid-svg-icons": "~5.9.0",
     "carbon-components": "~8.23.0",
-    "primeng": "~6.0.1",
-    "@fortawesome/fontawesome-free": "~5.9.0"
+    "primeng": "~6.0.1"
   },
   "devDependencies": {
     "angular2-template-loader": "~0.6.2",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "@angular/http": "~6.0.9",
     "@angular/platform-browser": "~6.0.9",
     "@angular/router": "~6.0.9",
-    "@fortawesome/angular-fontawesome": "~0.2.1",
-    "@fortawesome/fontawesome-svg-core": "~1.2.19",
-    "@fortawesome/free-solid-svg-icons": "~5.9.0",
     "carbon-components": "~8.23.0",
     "primeng": "~6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@angular/platform-browser": "~6.0.9",
     "@angular/router": "~6.0.9",
     "carbon-components": "~8.23.0",
-    "primeng": "~6.0.1"
+    "primeng": "~6.0.1",
+    "@fortawesome/fontawesome-free": "~5.9.0"
   },
   "devDependencies": {
     "angular2-template-loader": "~0.6.2",

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -9,16 +9,16 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-  <div>
+  <div style="height: 100%">
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowsermvs-search">
       <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTree();">
     </div>
-    <div [hidden]="hideExplorer">
-      <tree-root [treeData]="data" [style]="style"
-      (clickEvent)="clickInEventHandler($event)"
-      (contextmenu)="$event.preventDefault(); onRightClick($event);"></tree-root>
+    <div [hidden]="hideExplorer" style="height: 100%; overflow-y: scroll;">
+        <tree-root [treeData]="data" [style]="style"
+        (clickEvent)="clickInEventHandler($event)"
+        (contextmenu)="$event.preventDefault(); onRightClick($event);"></tree-root>
     </div>
   </div>
 <!-- 

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -13,12 +13,12 @@
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowsermvs-search">
-      <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTree();">
+      <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTreeAsync(path);">
     </div>
     <div [hidden]="hideExplorer" style="height: 100%; overflow-y: scroll;">
-        <tree-root [treeData]="data" [style]="style"
-        (clickEvent)="clickInEventHandler($event)"
-        (contextmenu)="$event.preventDefault(); onRightClick($event);"></tree-root>
+        <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)" [style]="style"
+          (contextmenu)="$event.preventDefault(); onRightClick($event);">
+        </tree-root>
     </div>
   </div>
 <!-- 

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -16,7 +16,8 @@
       <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTreeAsync(path);">
     </div>
     <div [hidden]="hideExplorer" style="height: 100%; overflow-y: scroll;">
-        <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)" [style]="style"
+        <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)"
+          (dblClickEvent)="onNodeDblClick($event)" [style]="style"
           (contextmenu)="$event.preventDefault(); onRightClick($event);">
         </tree-root>
     </div>

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -13,7 +13,7 @@
     <img src="../../../assets/explorer-uparrow.png" (click)="levelUp()" style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <!-- <svg width="14" height="16" viewBox="0 0 14 16" fill-rule="evenodd" (click)="levelUp()"><path d="M6 3.4V16h2V3.4l4.7 4.9L14 7 7 0 0 7l1.3 1.3z"></path></svg> -->
     <div class="filebrowsermvs-search">
-      <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTreeAsync(path);">
+      <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
     </div>
     <div [hidden]="hideExplorer" style="height: 100%;">
         <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)"

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -15,7 +15,7 @@
     <div class="filebrowsermvs-search">
       <input [(ngModel)]="path" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (change)="updateTreeAsync(path);">
     </div>
-    <div [hidden]="hideExplorer" style="height: 100%; overflow-y: scroll;">
+    <div [hidden]="hideExplorer" style="height: 100%;">
         <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)"
           (dblClickEvent)="onNodeDblClick($event)" [style]="style"
           (contextmenu)="$event.preventDefault(); onRightClick($event);">

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -185,47 +185,8 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
       })
     })
   }
-  
-  updateTreeSync(path: string): void{
-    this.pathChanged.emit(this.path);
-    this.fileService.queryDatasets(path).subscribe((res) =>{
-      if(res.datasets.length > 0){
-            let parents: TreeNode[] = [];
-            for(let i:number = 0; i < res.datasets.length; i++){
-              let currentNode:TreeNode = {};
-              currentNode.data = {};
-              currentNode.label = res.datasets[i].name.replace(/^\s+|\s+$/, '');
-              currentNode.data.id = i;
-              currentNode.data.path = currentNode.label
-              currentNode.data.fileName = currentNode.data.name = currentNode.data.path;
-              currentNode.data.isDataset = true;
-              currentNode.children = [];
-              if(res.datasets[i].members){
-                currentNode.type = 'Folder';
-                currentNode.expanded = false;
-                currentNode.expandedIcon = 'fa fa-folder-open';
-                currentNode.collapsedIcon = 'fa fa-database';
-                currentNode.data.hasChildren = true;
-                //data.id attribute is not used by either parent or child, but required as part of the ProjectStructure interface
-                this.addChildren(currentNode, res.datasets[i].members);
-              } else {
-                currentNode.type = 'nonPDS';
-                currentNode.expanded = false;
-                currentNode.icon = 'fa fa-cube';
-                currentNode.data.hasChildren = false;
-              }
-              parents.push(currentNode);
-            }
-            this.data = parents;
-          } else {
-            //data set probably doesnt exist
-          }
-        }, (err) => {
-          this.errorMessage = <any>err;
-      })
-  }
 
-  addChildren(parentNode: TreeNode, members: Array<any>){
+  addChildren(parentNode: TreeNode, members: Array<any>): void{
     for(let i: number = 0; i < members.length; i++){
       let childNode: TreeNode = {};
       childNode.type = 'nonPDS';
@@ -249,7 +210,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
 * [levelUp: function to ascend up a level in the file/folder tree]
 * @param index [tree index where the 'folder' parent is accessed]
 */
-  levelUp(): void {
+  levelUp(): void{
     if(!this.path.includes('.')){
       this.path = '';
     }

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -213,14 +213,14 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
       childNode.icon = 'fa fa-cube';
       childNode.label = members[i].name.replace(/^\s+|\s+$/, '');
       childNode.parent = parentNode;
-      childNode.data = {
+      let childNodeData: ProjectStructure = {
         id: parentNode.data.id,
-        fileName: childNode.label,
         name: childNode.label,
         hasChildren: false,
         isDataset: true,
-        path: `${parentNode.label}(${childNode.label})`
       }
+      childNodeData.path = childNodeData.fileName = `${parentNode.label}(${childNode.label})`;
+      childNode.data = childNodeData;
       parentNode.children.push(childNode);
     }
   }

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -195,7 +195,6 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
               currentNode.data.hasChildren = false;
             }
             parents.push(currentNode);
-            console.log('current node', currentNode);
           }
           this.data = parents;
         } else {

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -220,7 +220,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
         isDataset: true,
       }
       childNodeData.path = childNodeData.fileName = `${parentNode.label}(${childNode.label})`;
-      childNode.data = childNodeData;
+      childNode.data = (childNodeData as ProjectStructure);
       parentNode.children.push(childNode);
     }
   }

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -207,7 +207,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   addChildren(parentNode: TreeNode, members: Array<any>): void{
     for(let i: number = 0; i < members.length; i++){
       let childNode: TreeNode = {};
-      childNode.icon = 'fa fa-cube';
+      childNode.icon = 'fa fa-file';
       childNode.label = members[i].name.replace(/^\s+|\s+$/, '');
       childNode.parent = parentNode;
       let childNodeData: ProjectStructure = {

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -106,10 +106,8 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   onNodeClick($event: any): void{
     if($event.node.data.hasChildren){
       $event.node.expanded = !$event.node.expanded;
-      this.nodeClick.emit($event.node);
-    } else {
-      this.nodeClick.emit($event.node);
     }
+    this.nodeClick.emit($event.node);
   }
     
   onNodeDblClick($event: any): void{
@@ -118,9 +116,8 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
       this.updateTreeAsync($event.node.data.path).then((res) => {
         this.data = res[0].children;
       });
-    } else {
-      this.dblClickEvent.emit($event.node);
     }
+    this.dblClickEvent.emit($event.node);
   }
 
   onRightClick($event:any):void{

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -136,6 +136,9 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
       csiEntryType: queryRes.csiEntryType,
       name: queryRes.name,
     };
+    if(!!queryRes.members){
+      datasetAttrs.members = queryRes.members;
+    }
     if(!!queryRes.volser){
       datasetAttrs.volser = queryRes.volser;
     }
@@ -192,6 +195,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
               currentNode.data.hasChildren = false;
             }
             parents.push(currentNode);
+            console.log('current node', currentNode);
           }
           this.data = parents;
         } else {

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -181,17 +181,17 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
             };
             currentNode.data = currentNodeData;
             if(currentNode.data.datasetAttrs.dsorg
-              && currentNode.data.datasetAttrs.dsorg.organization === 'partitioned'
-              && res.datasets[i].members){
+                && currentNode.data.datasetAttrs.dsorg.organization === 'partitioned'
+                && res.datasets[i].members){
               currentNode.expanded = false;
               currentNode.expandedIcon = 'fa fa-folder-open';
-              currentNode.collapsedIcon = 'fa fa-database';
+              currentNode.collapsedIcon = 'fa fa-folder';
               currentNode.data.hasChildren = true;
               //data.id attribute is not used by either parent or child, but required as part of the ProjectStructure interface
               this.addChildren(currentNode, res.datasets[i].members);
             } else {
               currentNode.expanded = false;
-              currentNode.icon = 'fa fa-cube';
+              currentNode.icon = 'fa fa-file';
               currentNode.data.hasChildren = false;
             }
             parents.push(currentNode);

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -22,7 +22,6 @@ import { childEvent } from '../../structures/child-event';
 import { MvsDataObject } from '../../structures/persistantdata';
 import { Angular2InjectionTokens } from 'pluginlib/inject-resources';
 import { TreeNode } from 'primeng/primeng';
-import { faFolder, faFolderOpen, faFile, faFileArchive} from '@fortawesome/fontawesome-free-solid';
 
 /*import {FileBrowserFileSelectedEvent,
   IFileBrowserMVS
@@ -177,7 +176,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
               if(currentNode.data.datasetAttrs.volser
                   && (currentNode.data.datasetAttrs.volser == 'MIGRAT'
                   || currentNode.data.datasetAttrs.volser == 'ARCHIV')){
-                currentNode.icon = 'fa fa-file-archive';
+                currentNode.icon = 'fa fa-file-archive-o';
               } else {
                 currentNode.icon = 'fa fa-file';
               }

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -24,58 +24,6 @@
         </div>
     </div>
 
-    <!-- <p-dialog header="New File" [(visible)]="addFileDisplay" [modal]="false" [responsive]="true" [width]="350" [minWidth]="200" >
-        <input type="text" placeholder="New Name" name="newPath" [(ngModel)]="newPath">
-            <p-footer>
-                <button type="button" pButton (click)="addFileDisplay=false; addFile();" label="Ok">Ok</button>
-                <button type="button" pButton (click)="addFileDisplay=false" label="Cancel">Cancel</button>
-            </p-footer>
-    </p-dialog>
-    <p-dialog header="New Folder" [(visible)]="addFolderDisplay" [modal]="false" [responsive]="true" [width]="350" [minWidth]="200" >
-        <input type="text" placeholder="New Name" name="newPath" [(ngModel)]="newPath">
-            <p-footer>
-                <button type="button" pButton (click)="addFolderDisplay=false; addFolder();" label="Ok">Ok</button>
-                <button type="button" pButton (click)="addFolderDisplay=false" label="Cancel">Cancel</button>
-            </p-footer>
-    </p-dialog>
-    <p-dialog header="Copy" [(visible)]="copyDisplay" [modal]="false" [responsive]="true" [width]="350" [minWidth]="200" >
-        <span>Copy {{selectedItem}}</span>
-        <input type="text" placeholder="New Name" name="newPath" [(ngModel)]="newPath">
-            <p-footer>
-                <button type="button" pButton (click)="copyDisplay=false; copy();" label="Ok">Ok</button>
-                <button type="button" pButton (click)="copyDisplay=false" label="Cancel">Cancel</button>
-            </p-footer>
-    </p-dialog>
-    <p-dialog header="Rename" [(visible)]="renameDisplay" [modal]="false" [responsive]="true" [width]="350" [minWidth]="200" >
-        <span>Rename {{selectedItem}}</span>
-        <input type="text" placeholder="New Name" name="newPath" [(ngModel)]="newPath">
-            <p-footer>
-                <button type="button" pButton (click)="renameDisplay=false; rename();" label="Ok">Ok</button>
-                <button type="button" pButton (click)="renameDisplay=false" label="Cancel">Cancel</button>
-            </p-footer>
-    </p-dialog>
-<div class="filebrowseruss-dialog-menu">
-    <p-dialog header="" [(visible)]="rtClickDisplay" [modal]="false"
-    [responsive]="true" [showHeader]="false" [width]="auto" [height]="auto"
-            [baseZIndex]="10000" [positionLeft]="popUpMenuX" [positionTop]="popUpMenuY">
-            <div (click)="rtClickDisplay=false; onNewFileClick()">
-            New File
-            </div>
-            <div (click)="rtClickDisplay=false; onNewFolderClick()">
-            New Folder
-            </div>
-            <div (click)="rtClickDisplay=false; onDeleteClick($event)">
-            Delete
-            </div>
-            <div (click)="rtClickDisplay=false; onCopyClick($event)">
-            Copy
-            </div>
-            <div (click)="rtClickDisplay=false; onRenameClick($event)">
-            Rename
-            </div>
-    </p-dialog>
-</div> -->
-
 <!-- 
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -62,6 +62,7 @@
 
 .ui-treenode-icon {
   padding-right: 3px;
+  display: inline;
 }
 
 .ui-tree-empty-message {
@@ -71,6 +72,10 @@
 .ui-tree .ui-treenode-children {
   margin: 0;
   padding: 0 0 0 1em;
+}
+
+::-webkit-scrollbar-corner {
+  background: rgba(0,0,0,0);
 }
 
 

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -60,6 +60,11 @@
   padding-left: 3px;
 }
 
+.ui-treenode-label-italic {
+  padding-left: 3px;
+  font-style: italic;
+}
+
 .ui-treenode-icon {
   padding-right: 3px;
   display: inline;

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -55,14 +55,14 @@ export class TreeComponent {
  */
   nodeSelect(_event?: any) {
     if (_event){
-      if (this.lastClickedNodeName == null || this.lastClickedNodeName != _event.node.name) {
-      this.lastClickedNodeName = _event.node.name;
-      this.clickEvent.emit(_event); 
-      setTimeout( () => (this.lastClickedNodeName = null), this.lastClickedNodeTimeout);
-    } else {
-      this.dblClickEvent.emit(_event);
+      if (this.lastClickedNodeName == null || this.lastClickedNodeName != (_event.node.name || _event.node.data.name)) {
+        this.lastClickedNodeName = _event.node.name || _event.node.data.name;
+        this.clickEvent.emit(_event); 
+        setTimeout( () => (this.lastClickedNodeName = null), this.lastClickedNodeTimeout);
+      } else {
+        this.dblClickEvent.emit(_event);
+      }
     }
-  }
   }
 
   /**

--- a/src/app/components/zlux-file-explorer/zlux-file-explorer.component.html
+++ b/src/app/components/zlux-file-explorer/zlux-file-explorer.component.html
@@ -35,6 +35,7 @@
   ></file-browser-uss>
   <file-browser-mvs #mvsComponent
     [hidden]="currentIndex != 1"
+    (nodeClick)="onNodeClick($event)"
     (pathChanged)="onPathChanged($event)"
     [style]="style"
   ></file-browser-mvs>

--- a/src/app/services/file.service.ts
+++ b/src/app/services/file.service.ts
@@ -25,13 +25,13 @@ export class FileService {
 
   constructor(private http: Http){}
 
-    queryDatasets(query:string): Observable<any>  {
+    queryDatasets(query:string, detail?: boolean): Observable<any>  {
         let url:string;
         if (!query.includes('.')){
           url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
         }
         else{
-          url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), undefined, undefined, true);
+          url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true);
         }
         return this.http.get(url)
         .map(res=>res.json())

--- a/src/app/structures/editor-project.ts
+++ b/src/app/structures/editor-project.ts
@@ -1,0 +1,57 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+export interface ProjectStructure {
+    id: string;
+    name: string;
+    ext?: string;
+    language?: string;
+    children?: ProjectStructure[];
+    hasChildren: boolean;
+    contents?: string;
+    line?: number;
+    parent?: string;
+    path?: string;
+    fileName?: string;
+    isDataset: boolean;
+    encoding?: number;
+    datasetAttrs?: DatasetAttributes;
+}
+
+export interface DatasetAttributes {
+  csiEntryType: string,
+  name: string,
+  dsorg?: DatasetOrganization,
+  members?: Array<any>,
+  recfm?: RecordFormat,
+  volser?: string
+}
+
+export interface RecordFormat {
+  carriageControl: string;
+  isBlocked: boolean;
+  recordLength: string;
+}
+
+export interface DatasetOrganization {
+  maxRecordLen: number;
+  organization: string;
+  totalBlockSize: number;
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
Through the file explorer widget, users can now browse PDS as "Folders" with members/other data set types appearing as "files" within their parent data set.  Support for click to open PDS' (one click), drill-in navigation for PDS' (double click), click to collapse PDS', and searching with 3.4-like pattern.  Previous synchronous call to update data set view has been rewritten and made asynchronous.

Must merge with:
https://github.com/zowe/zlux-editor/pull/74