### PR TITLE
Removed font-awesome from package-lock, removed italics/added icon for migrated data sets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,35 +68,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "@fortawesome/angular-fontawesome": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.2.1.tgz",
-      "integrity": "sha512-B77fIEjq9bgHGncx5sfFuANh6qow6+MLHbU6C7lMIdeLXykkWTWOiPk+CqlmPOYXIpUH1lNaVykgTSqAk65pIw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.19.tgz",
-      "integrity": "sha512-nd2Ul/CUs8U9sjofQYAALzOGpgkVJQgEhIJnOHaoyVR/LeC3x2mVg4eB910a4kS6WgLPebAY0M2fApEI497raQ=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.19.tgz",
-      "integrity": "sha512-D4ICXg9oU08eF9o7Or392gPpjmwwgJu8ecCFusthbID95CLVXOgIyd4mOKD9Nud5Ckz+Ty59pqkNtThDKR0erA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.19"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.9.0.tgz",
-      "integrity": "sha512-U8YXPfWcSozsCW0psCtlRGKjjRs5+Am5JJwLOUmVHFZbIEWzaz4YbP84EoPwUsVmSAKrisu3QeNcVOtmGml0Xw==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.19"
-      }
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -196,7 +196,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
                 this.addChildren(currentNode, res.datasets[i].members);
               }
             } else {
-              if(migrated) currentNode.styleClass = 'ui-treenode-label-italic';
+              currentNode.icon = (migrated) ? 'fa fa-clock-o' : 'fa fa-file';
               currentNode.type = 'file';
               currentNode.icon = 'fa fa-file';
             }

--- a/src/app/components/tree/tree.component.css
+++ b/src/app/components/tree/tree.component.css
@@ -65,10 +65,6 @@
   display: table-cell;
 }
 
-.ui-treenode-label-italic {
-  font-style: italic;
-}
-
 .ui-treenode-icon {
   padding-right: 3px;
   display: table-cell;


### PR DESCRIPTION
Migrated data sets are now represented by a clock icon.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>