### PR TITLE
3.4-like searching

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -19,6 +19,9 @@
         <option *ngFor="let item of mvsSearchHistory.searchHistoryVal" [value]="item"></option>
       </datalist>
     </div>
+    <label>
+      Include Additional Qualifiers <input type="checkbox" [(ngModel)]="additionalQualifiers">
+    </label>
     <div [hidden]="hideExplorer" style="height: 100%;">
         <tree-root [treeData]="data" (clickEvent)="onNodeClick($event)"
           (dblClickEvent)="onNodeDblClick($event)" [style]="style"

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -44,6 +44,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   //capabilities:Array<Capability>;
   public hideExplorer: boolean;
   path: string;
+  additionalQualifiers: boolean;
   lastPath: string;
   rtClickDisplay: boolean;
   errorMessage: String;
@@ -66,6 +67,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.lastPath = "";
     this.rtClickDisplay = false;
     this.hideExplorer = false;
+    this.additionalQualifiers = true;
   }
   @Input() style: any;
   @Output() pathChanged: EventEmitter<any> = new EventEmitter<any>();
@@ -161,7 +163,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
 
   getTreeForQueryAsync(path: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.fileService.queryDatasets(path, true).pipe(take(1)).subscribe((res) => {
+      this.fileService.queryDatasets(path, true, this.additionalQualifiers).pipe(take(1)).subscribe((res) => {
         let parents: TreeNode[] = [];
         this.lastPath = path;
         if(res.datasets.length > 0){

--- a/src/app/services/file.service.ts
+++ b/src/app/services/file.service.ts
@@ -28,7 +28,7 @@ export class FileService {
 
     queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
       let url:string;
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, includeAdditionalQualifiers.toString());
+      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
       return this.http.get(url)
       .map(res=>res.json())
       .catch(this.handleErrorObservable);

--- a/src/app/services/file.service.ts
+++ b/src/app/services/file.service.ts
@@ -26,17 +26,12 @@ export class FileService {
 
   constructor(private http: Http){}
 
-    queryDatasets(query:string, detail?: boolean): Observable<any>  {
-        let url:string;
-        if (!query.includes('.')){
-          url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
-        }
-        else{
-          url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true);
-        }
-        return this.http.get(url)
-        .map(res=>res.json())
-        .catch(this.handleErrorObservable);
+    queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
+      let url:string;
+      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, includeAdditionalQualifiers.toString());
+      return this.http.get(url)
+      .map(res=>res.json())
+      .catch(this.handleErrorObservable);
     }
 
     getDataset(path:string) {


### PR DESCRIPTION
Dataset explorer now has a checkbox to toggle the equivalent of "Include Additional Qualifiers" in 3.4.  File service now supports call to new ZSS query parameter for dataset metadata, and no longer appends an asterisk to queries.  Now, this action is done server side.

Do not merge without:
https://github.com/zowe/zlux-platform/pull/34
https://github.com/zowe/zlux-app-manager/pull/138

Related to:
https://github.com/zowe/zowe-common-c/pull/77
https://github.com/zowe/zss/pull/75
