### PR TITLE
[WIP] "Include Addtional Qualifiers" toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1957,7 +1957,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2359,7 +2360,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2414,6 +2416,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2457,12 +2460,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -22,6 +22,9 @@
         <option *ngFor="let item of mvsSearchHistory.searchHistoryVal" [value]="item"></option>
       </datalist>
     </div>
+    <label>
+      Include Additional Qualifiers <input type="checkbox" [(ngModel)]="additionalQualifiers">
+    </label>
     <div class="fa fa-spinner fa-spin filebrowseruss-loading-icon" [hidden]="!isLoading"></div>
 
     <!-- Main tree -->

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -61,6 +61,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   private rightClickedFile: any;
   private rightClickPropertiesDataset: ContextMenuItem[];
   private deletionQueue = new Map();
+  private additionalQualifiers: boolean;
 
   constructor(private elementRef:ElementRef,
               private utils:UtilsService,
@@ -79,6 +80,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.lastPath = "";
     this.hideExplorer = false;
     this.isLoading = false;
+    this.additionalQualifiers = true;
   }
   @Input() style: any;
   @Output() pathChanged: EventEmitter<any> = new EventEmitter<any>();
@@ -347,7 +349,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   getTreeForQueryAsync(path: string): Promise<any> {
     return new Promise((resolve, reject) => {
       this.isLoading = true;
-      this.datasetService.queryDatasets(path, true).pipe(take(1)).subscribe((res) => {
+      this.datasetService.queryDatasets(path, true, this.additionalQualifiers).pipe(take(1)).subscribe((res) => {
         let parents: TreeNode[] = [];
         let parentMap = {};
         this.lastPath = path;

--- a/src/app/services/dataset.crud.service.ts
+++ b/src/app/services/dataset.crud.service.ts
@@ -79,13 +79,13 @@ export class DatasetCrudService {
     .catch(this.handleErrorObservable);
   }
 
-  queryDatasets(query:string, detail?: boolean): Observable<any>  {
+  queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
     let url:string;
     if (!query.includes('.')){
       url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
     }
     else{
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true);
+      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
     }
     return this.http.get(url)
     .map(res=>res.json())

--- a/src/app/services/dataset.crud.service.ts
+++ b/src/app/services/dataset.crud.service.ts
@@ -81,12 +81,7 @@ export class DatasetCrudService {
 
   queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
     let url:string;
-    // if (!query.includes('.')){
-    //   url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
-    // }
-    // else{
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
-    //}
+    url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
     return this.http.get(url)
     .map(res=>res.json())
     .catch(this.handleErrorObservable);

--- a/src/app/services/dataset.crud.service.ts
+++ b/src/app/services/dataset.crud.service.ts
@@ -81,12 +81,12 @@ export class DatasetCrudService {
 
   queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
     let url:string;
-    if (!query.includes('.')){
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
-    }
-    else{
+    // if (!query.includes('.')){
+    //   url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
+    // }
+    // else{
       url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
-    }
+    //}
     return this.http.get(url)
     .map(res=>res.json())
     .catch(this.handleErrorObservable);

--- a/zlux-file-explorer.ppf
+++ b/zlux-file-explorer.ppf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  This program and the accompanying materials are made available under the terms of the
+  Eclipse Public License v2.0 which accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+  SPDX-License-Identifier: EPL-2.0
+  Copyright Contributors to the Zowe Project.
+-->
+<Project default_configuration_name="Configuration 1" fallback_default_config_name="Configuration 1" file_encoding="ISO-8859-1" file_extension_set_name="javascript" ltd_name="javascript" name="zlux-file-explorer" version="9.0.3.11">
+	<Configuration name="Configuration 1"/>
+	<FileExtensions>
+		<FileExtension extension="js" is_exclude="false" is_project_exclusion="false" is_valid_assess="true" is_web="false"/>
+	</FileExtensions>
+	<Source exclude="false" path="." web="false"/>
+	<ProjectScanSettings cache_va="false" global_rules="false" string_analysis="false"/>
+</Project>


### PR DESCRIPTION
Dataset explorer now has a checkbox to toggle the equivalent of "Include Additional Qualifiers" in 3.4. File service now supports call to new ZSS query parameter for dataset metadata, and no longer appends an asterisk to queries. Now, this action is done server side.

Do not merge without:
https://github.com/zowe/zlux-platform/pull/34
https://github.com/zowe/zlux-app-manager/pull/138

Related to:
https://github.com/zowe/zowe-common-c/pull/108
https://github.com/zowe/zss/pull/75