### PR TITLE
Changed Search and Address Bar Hint Text

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -1,19 +1,19 @@
 
-<!--
+<!-- 
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
+  
   SPDX-License-Identifier: EPL-2.0
-
+  
   Copyright Contributors to the Zowe Project.
 -->
 
   <div style="height: 100%">
 
     <!-- Tabs, searchbar, and loading indicator -->
-    <img src="../../../assets/explorer-uparrow.png"
-      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()"
+    <img src="../../../assets/explorer-uparrow.png" 
+      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()" 
       style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <div class="filebrowsermvs-search">
       <input [(ngModel)]="path" list="searchMVSHistory" placeholder="Enter a dataset query..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
@@ -26,20 +26,20 @@
 
     <!-- Main tree -->
     <div [hidden]="hideExplorer" style="height: 100%;">
-      <tree-root [treeData]="data"
+      <tree-root [treeData]="data" 
         (clickEvent)="onNodeClick($event)"
-        (dblClickEvent)="onNodeDblClick($event)"
+        (dblClickEvent)="onNodeDblClick($event)" 
         [style]="style"
         (rightClickEvent)="onNodeRightClick($event)">
       </tree-root>
     </div>
   </div>
-<!--
+<!-- 
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
+  
   SPDX-License-Identifier: EPL-2.0
-
+  
   Copyright Contributors to the Zowe Project.
 -->

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -1,22 +1,22 @@
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->
 
   <div style="height: 100%">
 
     <!-- Tabs, searchbar, and loading indicator -->
-    <img src="../../../assets/explorer-uparrow.png" 
-      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()" 
+    <img src="../../../assets/explorer-uparrow.png"
+      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()"
       style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <div class="filebrowsermvs-search">
-      <input [(ngModel)]="path" list="searchMVSHistory" placeholder="Enter a dataset..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
+      <input [(ngModel)]="path" list="searchMVSHistory" placeholder="Enter a dataset query..." class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);">
       <!-- TODO: make search history a directive to use in both uss and mvs-->
       <datalist id="searchMVSHistory">
         <option *ngFor="let item of mvsSearchHistory.searchHistoryVal" [value]="item"></option>
@@ -26,20 +26,20 @@
 
     <!-- Main tree -->
     <div [hidden]="hideExplorer" style="height: 100%;">
-      <tree-root [treeData]="data" 
+      <tree-root [treeData]="data"
         (clickEvent)="onNodeClick($event)"
-        (dblClickEvent)="onNodeDblClick($event)" 
+        (dblClickEvent)="onNodeDblClick($event)"
         [style]="style"
         (rightClickEvent)="onNodeRightClick($event)">
       </tree-root>
     </div>
   </div>
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -1,19 +1,19 @@
 
-<!--
+<!-- 
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
+  
   SPDX-License-Identifier: EPL-2.0
-
+  
   Copyright Contributors to the Zowe Project.
 -->
 
 <div style="height: 100%;">
 
     <!-- Tabs, searchbar, and loading indicator -->
-    <img src="../../../assets/explorer-uparrow.png"
-      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()"
+    <img src="../../../assets/explorer-uparrow.png" 
+      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()" 
       style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <div class="filebrowseruss-search">
       <input #fileExplorerUSSInput [(ngModel)]="path" list="searchUSSHistory" placeholder="Enter an absolute path..." class="filebrowseruss-search-input"
@@ -27,9 +27,9 @@
 
     <!-- Main tree -->
     <div (click)="onClick($event);" [hidden]="hideExplorer" style="height: 100%;">
-      <tree-root [treeData]="data"
+      <tree-root [treeData]="data" 
         (clickEvent)="onNodeClick($event)"
-        (dblClickEvent)="onNodeDblClick($event)"
+        (dblClickEvent)="onNodeDblClick($event)" 
         [style]="style"
         (rightClickEvent)="onNodeRightClick($event)"
         (panelRightClickEvent)="onPanelRightClick($event)"
@@ -37,12 +37,12 @@
     </div>
 </div>
 
-<!--
+<!-- 
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-
+  
   SPDX-License-Identifier: EPL-2.0
-
+  
   Copyright Contributors to the Zowe Project.
--->
+-->``

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -45,4 +45,4 @@
   SPDX-License-Identifier: EPL-2.0
   
   Copyright Contributors to the Zowe Project.
--->``
+-->

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -1,22 +1,22 @@
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->
 
 <div style="height: 100%;">
 
     <!-- Tabs, searchbar, and loading indicator -->
-    <img src="../../../assets/explorer-uparrow.png" 
-      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()" 
+    <img src="../../../assets/explorer-uparrow.png"
+      data-toggle="tooltip" title="Go up to the parent level" (click)="levelUp()"
       style="width: 20px; height: 20px; filter: brightness(3); cursor: pointer;">
     <div class="filebrowseruss-search">
-      <input #fileExplorerUSSInput [(ngModel)]="path" list="searchUSSHistory" placeholder="Enter a directory..." class="filebrowseruss-search-input" 
+      <input #fileExplorerUSSInput [(ngModel)]="path" list="searchUSSHistory" placeholder="Enter an absolute path..." class="filebrowseruss-search-input"
         (keydown.enter)="displayTree(path, false); onPathChanged(path);" [disabled]="isLoading" (ngModelChange)="checkPathSlash($event)">
       <!-- TODO: make search history a directive to use in both uss and mvs-->
       <datalist id="searchUSSHistory">
@@ -27,9 +27,9 @@
 
     <!-- Main tree -->
     <div (click)="onClick($event);" [hidden]="hideExplorer" style="height: 100%;">
-      <tree-root [treeData]="data" 
+      <tree-root [treeData]="data"
         (clickEvent)="onNodeClick($event)"
-        (dblClickEvent)="onNodeDblClick($event)" 
+        (dblClickEvent)="onNodeDblClick($event)"
         [style]="style"
         (rightClickEvent)="onNodeRightClick($event)"
         (panelRightClickEvent)="onPanelRightClick($event)"
@@ -37,12 +37,12 @@
     </div>
 </div>
 
-<!-- 
+<!--
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 -->


### PR DESCRIPTION
Solves [this](https://github.com/zowe/zlux/issues/378) issue mentioned in `zlux-editor`

- changed Search bar text for datasets from "Enter a dataset" to "Enter a dataset query"
- changed Address bar text for files from “Enter a directory” to “Enter an absolute path”

Tested in `zlux-editor` as follows:
USS:
![](https://user-images.githubusercontent.com/30324532/73612195-91a22d80-460f-11ea-8bbd-cea62fb4abdc.png)
Dataset:
![](https://user-images.githubusercontent.com/30324532/73612197-936bf100-460f-11ea-9b36-51bbecfa5dd9.png)

Let me know if there are any further edits!
CC: @DivergentEuropeans @1000TurquoisePogs 