### PR TITLE
Added No results msg in MVS and USS tree

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -30,6 +30,7 @@
         (clickEvent)="onNodeClick($event)"
         (dblClickEvent)="onNodeDblClick($event)" 
         [style]="style"
+        noResultMsg="No results"
         (rightClickEvent)="onNodeRightClick($event)">
       </tree-root>
     </div>

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -31,6 +31,7 @@
         (clickEvent)="onNodeClick($event)"
         (dblClickEvent)="onNodeDblClick($event)" 
         [style]="style"
+        [noResultMsg]="noResultMsg"
         (rightClickEvent)="onNodeRightClick($event)"
         (panelRightClickEvent)="onPanelRightClick($event)"
       ></tree-root>

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -68,6 +68,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   private intervalId: any;
   private updateInterval: number = 10000;//time represents in ms how fast tree updates changes from mainframe
   @ViewChild('fileExplorerUSSInput') fileExplorerUSSInput: ElementRef;
+  private noResultMsg: String;
 
   constructor(private elementRef: ElementRef, 
     private ussSrv: UssCrudService,
@@ -453,6 +454,10 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
       this.log.debug("Tree has been updated.");
       this.log.debug(tempChildren);
       this.data = tempChildren;
+      if (this.data.length == 0) {
+        this.data = null;
+        this.noResultMsg = "Folder exists but is empty";
+      }
       this.path = path;
       this.onPathChanged(this.path);
 
@@ -466,6 +471,8 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
       //       })
       },
       error => {
+        this.data = null;
+        this.noResultMsg = "Folder does not exist"
         this.isLoading = false;
         this.errorMessage = <any>error;
       }

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -68,7 +68,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   private intervalId: any;
   private updateInterval: number = 10000;//time represents in ms how fast tree updates changes from mainframe
   @ViewChild('fileExplorerUSSInput') fileExplorerUSSInput: ElementRef;
-  private noResultMsg: String;
+  private noResultMsg: string;
 
   constructor(private elementRef: ElementRef, 
     private ussSrv: UssCrudService,

--- a/src/app/components/tree/tree.component.html
+++ b/src/app/components/tree/tree.component.html
@@ -30,6 +30,7 @@
     (onNodeContextMenuSelect)="nodeRightClickSelect($event)"
     [ngStyle]="style"
     [contextMenu]="dummy"
+    [emptyMessage]="noResultMsg"
   >
   <!-- add [filter]="true" with latest prime version (new feature March 2019) -->
   </p-tree>

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -39,7 +39,7 @@ import { FileNode } from '../../structures/file-node';
 export class TreeComponent implements AfterContentInit, OnDestroy {
   @Input() treeData: TreeNode;
   @Input() style: any;
-  @Input() noResultMsg: String;
+  @Input() noResultMsg: string;
   @Output() clickEvent = new EventEmitter<childEvent>();
   @Output() dblClickEvent = new EventEmitter<MouseEvent>();
   @Output() rightClickEvent = new EventEmitter<MouseEvent>();

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -39,6 +39,7 @@ import { FileNode } from '../../structures/file-node';
 export class TreeComponent implements AfterContentInit, OnDestroy {
   @Input() treeData: TreeNode;
   @Input() style: any;
+  @Input() noResultMsg: String;
   @Output() clickEvent = new EventEmitter<childEvent>();
   @Output() dblClickEvent = new EventEmitter<MouseEvent>();
   @Output() rightClickEvent = new EventEmitter<MouseEvent>();


### PR DESCRIPTION
Fixes https://github.com/zowe/zlux/issues/377

> If querying a dataset that does not exist, in the blank space below the address bar, include text “No results.”
> If querying a file that does not exist, in the blank space below the address bar, include text “Folder does not exist” or “Folder exists but is empty” depending on the case.

Used **emptyMessage** attribute of the p-tree.