### PR TITLE
Return Subject on deleting file

### DIFF
--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -659,13 +659,14 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
       );
   }
 
-  deleteFileOrFolder(rightClickedFile: any): void {
+  deleteFileOrFolder(rightClickedFile: any): Observable<any> {
     let pathAndName = rightClickedFile.path;
     let name = this.getNameFromPathAndName(pathAndName);
     this.isLoading = true;
     this.deletionQueue.set(rightClickedFile.path, rightClickedFile);
     rightClickedFile.styleClass = "filebrowseruss-node-deleting";
-    let deleteSubscription = this.ussSrv.deleteFileOrFolder(pathAndName)
+    let deleteObservable = this.ussSrv.deleteFileOrFolder(pathAndName);
+    let deleteSubscription = deleteObservable
     .subscribe(
       resp => {
         this.isLoading = false;
@@ -687,7 +688,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
           this.snackBar.open("Failed to delete '" + pathAndName + "' This is probably due to a permission problem.", 
           'Dismiss', { duration: 5000,   panelClass: 'center' });
         } else { //Unknown
-          this.snackBar.open("Uknown error '" + error.status + "' occured for: " + pathAndName, 
+          this.snackBar.open("Unknown error '" + error.status + "' occured for: " + pathAndName, 
           'Dismiss', { duration: 5000,   panelClass: 'center' });
           //Error info gets printed in uss.crud.service.ts
         }
@@ -704,6 +705,8 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
           'Dismiss', { duration: 5000,   panelClass: 'center' });
       }
     }, 4000);
+
+    return deleteObservable;
   }
 
   removeChild(node: any) {

--- a/src/app/components/zlux-file-explorer/zlux-file-explorer.component.ts
+++ b/src/app/components/zlux-file-explorer/zlux-file-explorer.component.ts
@@ -45,6 +45,7 @@ import { DeleteFileModal } from '../delete-file-modal/delete-file-modal.componen
 import { CreateFolderModal } from '../create-folder-modal/create-folder-modal.component';
 import { MatDialogModule, MatTableModule, MatSnackBarModule, MatFormFieldModule, MatIconModule, MatInputModule, MatListModule } from '@angular/material';
 import { DatasetPropertiesModal } from '@zlux/file-explorer/src/app/components/dataset-properties-modal/dataset-properties-modal.component';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'zlux-file-explorer',
@@ -113,7 +114,7 @@ export class ZluxFileExplorerComponent implements OnInit, OnDestroy {
     //   })
   }
 
-  deleteFileOrFolder(pathAndName: string): Observable<any> {
+  deleteFileOrFolder(pathAndName: string): Subject<any> {
     return this.ussComponent.deleteFileOrFolder(pathAndName);
   }
 

--- a/src/app/components/zlux-file-explorer/zlux-file-explorer.component.ts
+++ b/src/app/components/zlux-file-explorer/zlux-file-explorer.component.ts
@@ -113,8 +113,8 @@ export class ZluxFileExplorerComponent implements OnInit, OnDestroy {
     //   })
   }
 
-  deleteFileOrFolder(pathAndName: string) {
-    this.ussComponent.deleteFileOrFolder(pathAndName);
+  deleteFileOrFolder(pathAndName: string): Observable<any> {
+    return this.ussComponent.deleteFileOrFolder(pathAndName);
   }
 
   createDirectory(pathAndName?: string) {


### PR DESCRIPTION
This PR is a pre-requisites PR on https://github.com/zowe/zlux-editor/pull/138/ and is needed to fix https://github.com/zowe/zlux/issues/381

Basically, the editor code needs to subscribe to the delete observable to trigger automatic deletion of opened file tab.