### PR TITLE
[WIP] "Include Addtional Qualifiers" toggle

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -22,6 +22,9 @@
         <option *ngFor="let item of mvsSearchHistory.searchHistoryVal" [value]="item"></option>
       </datalist>
     </div>
+    <label>
+      Include Additional Qualifiers <input type="checkbox" [(ngModel)]="additionalQualifiers">
+    </label>
     <div class="fa fa-spinner fa-spin filebrowseruss-loading-icon" [hidden]="!isLoading"></div>
 
     <!-- Main tree -->

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -61,6 +61,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   private rightClickedFile: any;
   private rightClickPropertiesDataset: ContextMenuItem[];
   private deletionQueue = new Map();
+  private additionalQualifiers: boolean;
 
   constructor(private elementRef:ElementRef,
               private utils:UtilsService,
@@ -79,6 +80,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
     this.lastPath = "";
     this.hideExplorer = false;
     this.isLoading = false;
+    this.additionalQualifiers = true;
   }
   @Input() style: any;
   @Output() pathChanged: EventEmitter<any> = new EventEmitter<any>();
@@ -347,7 +349,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   getTreeForQueryAsync(path: string): Promise<any> {
     return new Promise((resolve, reject) => {
       this.isLoading = true;
-      this.datasetService.queryDatasets(path, true).pipe(take(1)).subscribe((res) => {
+      this.datasetService.queryDatasets(path, true, this.additionalQualifiers).pipe(take(1)).subscribe((res) => {
         let parents: TreeNode[] = [];
         let parentMap = {};
         this.lastPath = path;

--- a/src/app/services/dataset.crud.service.ts
+++ b/src/app/services/dataset.crud.service.ts
@@ -79,14 +79,9 @@ export class DatasetCrudService {
     .catch(this.handleErrorObservable);
   }
 
-  queryDatasets(query:string, detail?: boolean): Observable<any>  {
+  queryDatasets(query:string, detail?: boolean, includeAdditionalQualifiers?: boolean): Observable<any>  {
     let url:string;
-    if (!query.includes('.')){
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ) + '*');
-    }
-    else{
-      url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true);
-    }
+    url = ZoweZLUX.uriBroker.datasetMetadataUri(query.toUpperCase( ).replace(/\.$/, ''), detail.toString(), undefined, true, undefined, undefined, undefined, undefined, undefined, includeAdditionalQualifiers.toString());
     return this.http.get(url)
     .map(res=>res.json())
     .catch(this.handleErrorObservable);


### PR DESCRIPTION
Dataset explorer now has a checkbox to toggle the equivalent of "Include Additional Qualifiers" in 3.4. File service now supports call to new ZSS query parameter for dataset metadata, and no longer appends an asterisk to queries. Now, this action is done server side.

Do not merge without:
zowe/zlux-platform#34
zowe/zlux-app-manager#138

Related to:
zowe/zowe-common-c#108
zowe/zss#143

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>