### PR TITLE
Update node-sass version to support node 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3970,9 +3970,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha1-GD+uw5jpy+k7pDNi4naMqYimNpo=",
+      "version": "4.12.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-sass/-/node-sass-4.12.0.tgz",
+      "integrity": "sha1-CRT1MZMjgBFKMMxfpPpjIzol8Bc=",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "file-loader": "~1.1.11",
     "html-loader": "~0.5.5",
     "html-webpack-plugin": "~3.2.0",
-    "node-sass": "~4.11.0",
+    "node-sass": "~4.12.0",
     "rxjs": "~6.2.2",
     "rxjs-compat": "~6.2.2",
     "source-map-loader": "~0.2.3",


### PR DESCRIPTION
- Node v12 requires **node-sass** version **4.12.0**  (Reference: https://github.com/nodejs/node-gyp/issues/1763#issuecomment-497138736 )
- [node-sass v4.12.0](https://github.com/sass/node-sass/releases/tag/v4.12.0) is supported by environments
![image](https://user-images.githubusercontent.com/29533998/90675924-c65a9700-e278-11ea-87da-77d67bac958f.png)





Signed-off-by: Mitesh <mgoplani@rocketsoftware.com>