### PR TITLE
Bugfix for copy & cut being mixed up during the paste step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.5.0
 
 * Added cut, copy, and paste functionality to USS files.
-* onPathChanged emitter now fires from MVS as well & deprecated some old code.
+* onPathChanged emitter now fires from MVS as well
+* Removed unused & dead code.
 
 ## 0.4.0
 

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -240,35 +240,41 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   }
 
   copyFile(rightClickedFile: any) {
-    if(this.fileToCopyOrCut == null){
-      this.rightClickPropertiesFolder.push( // Create a paste option for the folder
-        { text: "Paste", action:() => { 
-          this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, false)
-        }}
-      );
-      this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
-        { text: "Paste", action:() => { 
-          this.pasteFile(this.fileToCopyOrCut, this.path, false)
-        }}
-      );
+    if (this.fileToCopyOrCut) {
+      this.rightClickPropertiesFolder.splice(this.rightClickPropertiesFolder.map(item => item.text).indexOf("Paste"),1);
+      this.rightClickPropertiesPanel.splice(this.rightClickPropertiesPanel.map(item => item.text).indexOf("Paste"),1);
     }
+    this.log.debug(`copyfile for  ${this.fileToCopyOrCut}, ${this.rightClickedFile.path}, ${this.path}`);
+    this.rightClickPropertiesFolder.push( // Create a paste option for the folder
+      { text: "Paste", action:() => { 
+        this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, false)
+      }}
+    );
+    this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
+      { text: "Paste", action:() => { 
+        this.pasteFile(this.fileToCopyOrCut, this.path, false)
+      }}
+    );
     this.fileToCopyOrCut = rightClickedFile;
     this.copyClick.emit(rightClickedFile);
   }
 
   cutFile(rightClickedFile: any) {
-    if(this.fileToCopyOrCut == null){
-      this.rightClickPropertiesFolder.push( // Create a paste option for the folder
-        { text: "Paste", action:() => { 
-          this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, true)
-        }}
-      );
-      this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
-        { text: "Paste", action:() => { 
-          this.pasteFile(this.fileToCopyOrCut, this.path, true)
-        }}
-      );
+    if (this.fileToCopyOrCut) {
+      this.rightClickPropertiesFolder.splice(this.rightClickPropertiesFolder.map(item => item.text).indexOf("Paste"),1);
+      this.rightClickPropertiesPanel.splice(this.rightClickPropertiesPanel.map(item => item.text).indexOf("Paste"),1);
     }
+    this.log.debug(`cutfile for  ${this.fileToCopyOrCut}, ${this.rightClickedFile.path}, ${this.path}`);
+    this.rightClickPropertiesFolder.push( // Create a paste option for the folder
+      { text: "Paste", action:() => { 
+        this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, true)
+      }}
+    );
+    this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
+      { text: "Paste", action:() => { 
+        this.pasteFile(this.fileToCopyOrCut, this.path, true)
+      }}
+    );
     this.fileToCopyOrCut = rightClickedFile;
     this.copyClick.emit(rightClickedFile);
   }
@@ -276,6 +282,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   pasteFile(fileNode: any, destinationPath: any, isCut: boolean) {
     let pathAndName = fileNode.path;
     let name = this.getNameFromPathAndName(pathAndName);
+    this.log.debug(`paste for ${name}, ${destinationPath}, and cut=${isCut}`);
     if(this.getPathFromPathAndName(pathAndName) == destinationPath){
       this.snackBar.open("Paste failed: '" + pathAndName + "' Cannot paste file to same destination.",
         'Dismiss', defaultSnackbarOptions);

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -240,21 +240,19 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   }
 
   copyFile(rightClickedFile: any) {
-    if (this.fileToCopyOrCut) {
-      this.rightClickPropertiesFolder.splice(this.rightClickPropertiesFolder.map(item => item.text).indexOf("Paste"),1);
-      this.rightClickPropertiesPanel.splice(this.rightClickPropertiesPanel.map(item => item.text).indexOf("Paste"),1);
-    }
     this.log.debug(`copyfile for  ${this.fileToCopyOrCut}, ${this.rightClickedFile.path}, ${this.path}`);
-    this.rightClickPropertiesFolder.push( // Create a paste option for the folder
-      { text: "Paste", action:() => { 
-        this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, false)
-      }}
-    );
-    this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
-      { text: "Paste", action:() => { 
-        this.pasteFile(this.fileToCopyOrCut, this.path, false)
-      }}
-    );
+    if (this.fileToCopyOrCut == null) {
+      this.rightClickPropertiesFolder.push( // Create a paste option for the folder
+        { text: "Paste", action:() => { 
+          this.pasteFile(this.fileToCopyOrCut, this.rightClickedFile.path, false)
+        }}
+      );
+      this.rightClickPropertiesPanel.push( // Create a paste option for the active directory
+        { text: "Paste", action:() => { 
+          this.pasteFile(this.fileToCopyOrCut, this.path, false)
+        }}
+      );
+    }
     this.fileToCopyOrCut = rightClickedFile;
     this.copyClick.emit(rightClickedFile);
   }


### PR DESCRIPTION
The paste command was not cleared when switching between copy and cut so if a copy ever occurred no other cuts could ever occur, they would all be treated as copy.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>