### PR TITLE
update build label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-node('ibm-jenkins-slave-nvm') {
+node('zowe-jenkins-agent') {
   def lib = library("jenkins-library").org.zowe.jenkins_shared_library
 
   def pipeline = lib.pipelines.nodejs.NodeJSPipeline.new(this)


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Part of the fixes for https://github.com/zowe/zlc/issues/199.

The label is pointed to exactly same Docker image hash but different image name to remove word `slave`.