### PR TITLE
Displaying the MVS dataset properties in the dialog

### DIFF
--- a/src/app/components/dataset-properties-modal/dataset-properties-modal.component.ts
+++ b/src/app/components/dataset-properties-modal/dataset-properties-modal.component.ts
@@ -38,7 +38,10 @@ export class DatasetPropertiesModal implements OnInit {
     @Inject(MAT_DIALOG_DATA) data,
   ) 
   {
-    const node = data.event;
+    let node = data.event;
+    if(node && !node.data) {
+      node = { data: { datasetAttrs: JSON.parse(JSON.stringify(node)), fileName: node.fullName}}
+    }
     if (node.data) {
       const data = node.data;
       this.datasetName = data.fileName;


### PR DESCRIPTION
Previously the MVS dataset properties dialog was blank due to the mismatch in the structure of the JSON object send from the file-manager to the explorer.
Now after making the appropriate changes in the file-manager and explorer the dialog displays the properties of the MVS Datasets.