### PR TITLE
fixing the console error that could occur when the file we trying to refresh is not visible in the File-explorer tree of editor

### DIFF
--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -1016,7 +1016,7 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
 
   refreshFileMetadatdaUsingPath(path: string) {
     let foundNode = this.findNodeByPath(this.data , path)[0];
-    if ( foundNode ) {
+    if (foundNode) {
       this.refreshFileMetadata(foundNode);  
     }
   }

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -1015,7 +1015,10 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   }
 
   refreshFileMetadatdaUsingPath(path: string) {
-    this.refreshFileMetadata(this.findNodeByPath(this.data , path)[0]);  
+    let foundNode = this.findNodeByPath(this.data , path)[0];
+    if ( foundNode ) {
+      this.refreshFileMetadata(foundNode);  
+    }
   }
 
   searchInputChanged(input: string) {


### PR DESCRIPTION
fixing the console error that could occur when the file we trying to refresh, automatically after saving of file happens, is not visible in the File-explorer tree of the editor

Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>