### PR TITLE
Use user-info service to get home dir

### DIFF
--- a/src/app/services/uss.crud.service.ts
+++ b/src/app/services/uss.crud.service.ts
@@ -92,7 +92,7 @@ export class UssCrudService {
   }
   
   getUserHomeFolder(): Observable<{home: string}>{
-    let url :string = ZoweZLUX.uriBroker.omvsSegmentUri();
+    let url :string = ZoweZLUX.uriBroker.userInfoUri();
     return this.http.get(url)
     .map(res=>res.json())
     .catch(this.handleErrorObservable);


### PR DESCRIPTION
This PR updates file-explorer to use `/user-info` service to get home dir.

This PR depends upon:
* https://github.com/zowe/zlux-platform/pull/79
* https://github.com/zowe/zlux-app-manager/pull/371
* https://github.com/zowe/zss/pull/336