### PR TITLE
Small fixes for ownership and permissions dialogs

### DIFF
--- a/src/app/components/file-ownership-modal/file-ownership-modal.component.ts
+++ b/src/app/components/file-ownership-modal/file-ownership-modal.component.ts
@@ -16,8 +16,6 @@ import { HttpClient } from '@angular/common/http';
 import { defaultSnackbarOptions } from '../../shared/snackbar-options';
 import { finalize, catchError, map } from "rxjs/operators";
 
-const OWNERSHIP_SUCCESS_MSG = "Successfully Modify ";
-
 @Component({
   selector: 'file-ownership-modal',
   templateUrl: './file-ownership-modal.component.html',
@@ -104,11 +102,11 @@ export class FileOwnershipModal {
 
   saveOwnerInfo() {
     let url :string = ZoweZLUX.uriBroker.unixFileUri('chown', this.path, undefined, undefined, undefined, false, undefined, undefined, undefined, undefined, this.recursive, this.owner, this.group);
-    this.http.post(url, null).pipe(
+    this.http.post(url, null, {observe: 'response'}).pipe(
       finalize(() => this.closeDialog()),
     ).subscribe(
         (res: any) => {
-          if (res.msg == OWNERSHIP_SUCCESS_MSG) {
+          if (res.status == 200) {
             this.snackBar.open(this.path + ' has been successfully changed to Owner: ' + this.owner + " Group: " + this.group + ".",
               'Dismiss', defaultSnackbarOptions);
             this.node.owner = this.owner;

--- a/src/app/components/file-permissions-modal/file-permissions-modal.component.ts
+++ b/src/app/components/file-permissions-modal/file-permissions-modal.component.ts
@@ -18,8 +18,6 @@ import { FormControl } from '@angular/forms';
 import { defaultSnackbarOptions } from '../../shared/snackbar-options';
 import { finalize, catchError, map } from "rxjs/operators";
 
-const PERMISSIONS_SUCCESS_MSG = "successfully modify modes";
-
 @Component({
   selector: 'file-permissions-modal',
   templateUrl: './file-permissions-modal.component.html',
@@ -279,11 +277,11 @@ export class FilePermissionsModal {
 
   savePermissions() {
     let url :string = ZoweZLUX.uriBroker.unixFileUri('chmod', this.path, undefined, undefined, undefined, false, undefined, undefined, undefined, this.octalMode, this.recursive);
-    this.http.post(url, null).pipe(
+    this.http.post(url, null, {observe: 'response'}).pipe(
       finalize(() => this.closeDialog()),
     ).subscribe(
       (res: any) => {
-        if (res.msg == PERMISSIONS_SUCCESS_MSG) {
+        if (res.status == 200) {
           this.snackBar.open(this.path + ' has been successfully changed to ' + this.octalMode + ".",
             'Dismiss', defaultSnackbarOptions);
           this.node.mode = parseInt(this.octalMode, 10);


### PR DESCRIPTION
This PR contains small fixes for ownership and permissions dialogs. It's more robust to check `res.status` because `res.msg` can be changed in future.