### PR TITLE
Toolbar buttons alignment

### DIFF
--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.css
@@ -21,6 +21,7 @@
   margin-left: 5px;
   display: inline-block;
   height: 40px;
+  padding-right: 15px;
 }
 
 .filebrowsermvs-search-input{
@@ -68,12 +69,12 @@
 }
 
 .filebrowsermvs-loading-icon {
-  margin-left: 8px !important;
   font-size: large !important;
 }
 
 .filebrowsermvs-plus-icon {
   font-size: large;
+  margin-left: -11px;
 }
 
 /*

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -40,7 +40,7 @@
     </div>
   </div>
 
-  <div class="fa fa-plus filebrowsermvs-plus-icon" title="Create new dataset" (click)="createDatasetDialog()" style="cursor: pointer;"></div>
+  <div class="fa fa-plus filebrowsermvs-plus-icon" title="Allocate new data set" (click)="createDatasetDialog()" style="cursor: pointer;"></div>
   <div class="fa fa-spinner fa-spin filebrowsermvs-loading-icon" [hidden]="!isLoading" style="margin-left: 6px;"></div>
   <div class="fa fa-refresh filebrowsermvs-loading-icon" title="Refresh dataset list" (click)="updateTreeView(path);" [hidden]="isLoading" style="margin-left: 9px; cursor: pointer;"></div>
   <div class="file-tree-utilities">

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -40,8 +40,8 @@
     </div>
   </div>
 
-  <div class="fa fa-plus filebrowsermvs-plus-icon" title="Create new dataset" (click)="createDatasetDialog()" style="margin-left:4px; cursor: pointer;"></div>
-  <div class="fa fa-spinner fa-spin filebrowsermvs-loading-icon" [hidden]="!isLoading"></div>
+  <div class="fa fa-plus filebrowsermvs-plus-icon" title="Create new dataset" (click)="createDatasetDialog()" style="cursor: pointer;"></div>
+  <div class="fa fa-spinner fa-spin filebrowsermvs-loading-icon" [hidden]="!isLoading" style="margin-left: 6px;"></div>
   <div class="fa fa-refresh filebrowsermvs-loading-icon" title="Refresh dataset list" (click)="updateTreeView(path);" [hidden]="isLoading" style="margin-left: 9px; cursor: pointer;"></div>
   <div class="file-tree-utilities">
     <div class="fa fa-minus-square-o filebrowseruss-collapse-icon" title="Collapse Folders in Explorer" (click)="collapseTree();" style="margin-right: 9px; float:right; cursor: pointer;"></div>


### PR DESCRIPTION
Aligning the  'refresh' and 'create-dataset' buttons in the FT toolbar
The tooltip for the button is renamed to - 'Allocate new dataset'