### PR TITLE
encoding the URL when copying the URL link to file or DS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0
 * Added a UI for creating datasets
+* Bugfix: Getting 400 BAD REQUEST in browser when opening the file or dataset after copying its link
 
 ## 1.2.0
 * Added the option to receive USS/MVS node data

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -393,9 +393,9 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {//IFileBrowse
   copyLink(rightClickedFile: any) {
     let link = '';
     if(rightClickedFile.type == 'file'){
-       link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:{"type":"openDataset","name":"${encodeURIComponent(rightClickedFile.data.path)}","toggleTree":true}`;
+       link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDataset","name":"${rightClickedFile.data.path}","toggleTree":true}`)}`;
     } else {
-      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:{"type":"openDSList","name":"${encodeURIComponent(rightClickedFile.data.path)}","toggleTree":false}`;
+      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDSList","name":"${rightClickedFile.data.path}","toggleTree":false}`)}`;
     }
     navigator.clipboard.writeText(link).then(() => {
       this.log.debug("Link copied to clipboard");

--- a/src/app/components/filebrowseruss/filebrowseruss.component.ts
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.ts
@@ -699,9 +699,9 @@ export class FileBrowserUSSComponent implements OnInit, OnDestroy {//IFileBrowse
   copyLink(rightClickedFile: any) {
     let link = '';
     if (rightClickedFile.directory){
-      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:{"type":"openDir","name":"${encodeURIComponent(rightClickedFile.path)}","toggleTree":false}`;
+      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openDir","name":"${rightClickedFile.path}","toggleTree":false}`)}`;
     } else {
-      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:{"type":"openFile","name":"${encodeURIComponent(rightClickedFile.path)}","toggleTree":true}`;
+      link = `${window.location.origin}${window.location.pathname}?pluginId=${this.pluginDefinition.getBasePlugin().getIdentifier()}:data:${encodeURIComponent(`{"type":"openFile","name":"${rightClickedFile.path}","toggleTree":true}`)}`;
     }
     navigator.clipboard.writeText(link).then(() => {
       this.log.debug("Link copied to clipboard");


### PR DESCRIPTION
Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>
PROBLEM: When accessing the desktop using gateway port, then trying opening a file or DS after copying its link to clipboard, will result in 400 BAD REQUEST in browser.
This happens because the URL is not encoded properly