### PR TITLE
Make FT easy to read again (reorganize, comment, and bugfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ZLUX Angular File Tree
 
+## 1.4.0
+* Bugfix: Make it so an MVS double click ("drill into") event correctly emits a path change
+* Bugfix: Clean up all USS/MVS subscriptions
+* Remove unnecessary MVS data fetch update feature (currently it's 3000000 ms or 50 minutes)
+* Add clarifying comments, renames, TODOs, and organization to variables, services, and a few methods
+
 ## 1.3.0
 * Added a UI for creating datasets
 * Bugfix: Getting 400 BAD REQUEST in browser when opening the file or dataset after copying its link

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zlux-angular-file-tree",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zlux-angular-file-tree",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/main.js",
   "homepage": "https://github.com/zowe/zlux-file-explorer/blob/staging/README.md",
   "bugs": {

--- a/src/app/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/src/app/components/filebrowsermvs/filebrowsermvs.component.html
@@ -64,8 +64,8 @@
     <input type="text" pInputText 
       placeholder="Search datasets/members by name..." 
       class="filebrowseruss-search-bottom-input" 
-      [formControl]="searchInputCtrl"
-      #searchInputMVS>         
+      [formControl]="searchCtrl"
+      #searchMVS>         
   </div>
 </div>
 <!-- 

--- a/src/app/components/filebrowseruss/filebrowseruss.component.html
+++ b/src/app/components/filebrowseruss/filebrowseruss.component.html
@@ -59,8 +59,8 @@
     <input type="text" pInputText 
       placeholder="Search opened files/folders by name..." 
       class="filebrowseruss-search-bottom-input" 
-      [formControl]="searchInputCtrl"
-      #searchInputUSS>       
+      [formControl]="searchCtrl"
+      #searchUSS>       
   </div>
 
 </div>

--- a/src/app/services/searchHistoryService.ts
+++ b/src/app/services/searchHistoryService.ts
@@ -23,7 +23,7 @@ export class SearchHistoryService {
     
   }
 
-  onInit(type:string) {
+  onInit(type: string) { //'uss' or 'mvs'
     this.type = type;
     this.basePlugin = this.pluginDefinition.getBasePlugin();
     this.resourceName = `${type}Search.json`;


### PR DESCRIPTION
The purposes of this PR:
- bugfix: make it so an MVS double click ("drill into") event correctly emits a path change
- bugfix: clean up all USS/MVS subscriptions
- remove unnecessary MVS data fetch update feature (currently it's 3000000 ms or 50 minutes)
- add clarifying comments, renames, TODOs, and organization to variables, services, and a few methods

Signed-off-by: Leanid Astrakou <LeanyIA@yahoo.com>