### PR TITLE
Fixing FT Selection

### DIFF
--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
@@ -54,6 +54,8 @@
 .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight {
   background-color: #e0e0e0;
   color: black;
+  border-radius: 5px;
+  padding: 0 2px;
 }
 
 .p-tree .p-treenode-label.p-state-highlight {

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
@@ -53,7 +53,7 @@
 
 .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight {
   background-color: #e0e0e0;
-  color: yellow;
+  color: black;
 }
 
 .p-tree .p-treenode-label.p-state-highlight {

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
@@ -53,6 +53,7 @@
 
 .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight {
   background-color: #e0e0e0;
+  color: yellow;
 }
 
 .p-tree .p-treenode-label.p-state-highlight {

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
@@ -17,7 +17,7 @@
     [(selection)]="selectedNode"
     (onNodeContextMenuSelect)="nodeRightClickSelect($event)"
     (onNodeSelect)="nodeSelect($event)"
-    (onNodeUnselect)="nodeUnselect($event)"
+    [metaKeySelection]="false"
     [ngStyle]="treeStyle"
     [contextMenu]="dummy"
     emptyMessage=""

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
@@ -17,7 +17,7 @@
     [(selection)]="selectedNode"
     (onNodeContextMenuSelect)="nodeRightClickSelect($event)"
     (onNodeSelect)="nodeSelect($event)"
-    (onNodeUnselect)="nodeSelect($event)"
+    (onNodeUnselect)="nodeUnselect($event)"
     [ngStyle]="treeStyle"
     [contextMenu]="dummy"
     emptyMessage=""

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.html
@@ -17,7 +17,7 @@
     [(selection)]="selectedNode"
     (onNodeContextMenuSelect)="nodeRightClickSelect($event)"
     (onNodeSelect)="nodeSelect($event)"
-    [metaKeySelection]="false"
+    (onNodeUnselect)="nodeSelect($event)"
     [ngStyle]="treeStyle"
     [contextMenu]="dummy"
     emptyMessage=""

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -69,16 +69,14 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
       return;
     }
 
-    const isDirectory = _event.node.directory;
-    // if (!isDirectory) {
-    //   // File click is always treated as single click
-    //   this.clickEvent.emit(_event);
-    //   return;
-    // }
+    const isDirectory = _event.node?.directory;
+    const type = _event.node?.type;
 
     if (this.clickTimer && this.lastClickedNode === _event.node) {
       this.resetClickDetection();
-      if(!isDirectory) {
+
+      // Indicates a file, dataset member, or sequential dataset where double-click has no additional effect
+      if((!type && !isDirectory) || (type === 'file') ) {
         this.clickEvent.emit(_event);
         return;
       }
@@ -98,6 +96,12 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
     }
     this.clickTimer = null;
     this.lastClickedNode = null;
+  }
+
+  nodeUnselect(_event?: any) {
+    this.selectedNode = _event.node;
+    // Calling nodeSelect to detect a double click
+    this.nodeSelect(_event);
   }
 
   nodeRightClickSelect(_event?: any) {

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -51,6 +51,7 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
   selectedNode: FileNode;
   private readonly doubleClickThreshold  : number = 300; // Interval of 300ms or less between two clicks is considered a double-click here.
   clickTimer: any = null;
+  lastClickedNode: any = null;
   @ViewChild('fileExplorerPTree', { static: true }) fileExplorerTree: ElementRef;
 
   /**
@@ -64,21 +65,35 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
   // If user clicks the same node before timer expires, treat it as a double-click & clear the timer. Else, handle the original select/unselect event.
 
   nodeSelect(_event?: any) {
-    if (_event) {
-      console.log("Node select fro, FT---", _event);
-      if (this.clickTimer) {
-        console.log('Dbl click---');
-        this.dblClickEvent.emit(_event);
-        clearTimeout(this.clickTimer);
-        this.clickTimer = null;
-      } else {
-        console.log('Single click---');
-        this.clickTimer = setTimeout(() => {
-          this.clickEvent.emit(_event);
-          this.clickTimer = null;
-        }, this.doubleClickThreshold );
-      }
+    if (!_event) {
+      return;
     }
+
+    const isDirectory = _event.node.directory;
+    if (!isDirectory) {
+      // File click is always treated as single click
+      this.clickEvent.emit(_event);
+      return;
+    }
+
+    if (this.clickTimer && this.lastClickedNode === _event.node) {
+      this.resetClickDetection();
+      this.dblClickEvent.emit(_event);
+    } else {
+      this.lastClickedNode = _event.node;
+      this.clickTimer = setTimeout(() => {
+        this.resetClickDetection();
+        this.clickEvent.emit(_event);
+      }, this.doubleClickThreshold );
+    }
+  }
+
+  resetClickDetection() {
+    if (this.clickTimer) {
+      clearTimeout(this.clickTimer);
+    }
+    this.clickTimer = null;
+    this.lastClickedNode = null;
   }
 
   nodeRightClickSelect(_event?: any) {

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -69,8 +69,14 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
       return;
     }
 
+    console.log('---Event: ', _event);
+
     const isDirectory = _event.node?.directory;
     const type = _event.node?.type;
+
+    if(isDirectory === undefined && type === undefined) {
+      return;
+    }
 
     if (this.clickTimer && this.lastClickedNode === _event.node) {
       this.resetClickDetection();

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -79,11 +79,6 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
     const isPDSFolder = this.utils.isPDSDataset(node);
     const isDatasetFile = this.utils.isDatasetFile(node);
 
-    console.log('isUnixDirectory', isUnixDirectory);
-    console.log('isUnixFile', isUnixFile);
-    console.log('isPDSFolder', isPDSFolder);
-    console.log('isDatasetFile', isDatasetFile);
-
     if (!isUnixDirectory && !isUnixFile && !isPDSFolder && !isDatasetFile) {
       return;
     }

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -93,12 +93,12 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
         this.dblClickEvent.emit(_event);
       }
     } else {
-      this.registerSingleClick(node, _event);
+      this.registerSingleClick(_event);
     }
   }
 
-  registerSingleClick(node: any, _event: any): void {
-    this.lastClickedNode = node;
+  registerSingleClick(_event: any): void {
+    this.lastClickedNode = _event?.node;
     if (this.clickTimer) {
       clearTimeout(this.clickTimer);
     }

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -70,14 +70,18 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
     }
 
     const isDirectory = _event.node.directory;
-    if (!isDirectory) {
-      // File click is always treated as single click
-      this.clickEvent.emit(_event);
-      return;
-    }
+    // if (!isDirectory) {
+    //   // File click is always treated as single click
+    //   this.clickEvent.emit(_event);
+    //   return;
+    // }
 
     if (this.clickTimer && this.lastClickedNode === _event.node) {
       this.resetClickDetection();
+      if(!isDirectory) {
+        this.clickEvent.emit(_event);
+        return;
+      }
       this.dblClickEvent.emit(_event);
     } else {
       this.lastClickedNode = _event.node;

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -98,12 +98,6 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
     this.lastClickedNode = null;
   }
 
-  nodeUnselect(_event?: any) {
-    this.selectedNode = _event.node;
-    // Calling nodeSelect to detect a double click
-    this.nodeSelect(_event);
-  }
-
   nodeRightClickSelect(_event?: any) {
     if (_event) {
       this.rightClickEvent.emit(_event);

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -65,11 +65,14 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
 
   nodeSelect(_event?: any) {
     if (_event) {
+      console.log("Node select fro, FT---", _event);
       if (this.clickTimer) {
+        console.log('Dbl click---');
         this.dblClickEvent.emit(_event);
         clearTimeout(this.clickTimer);
         this.clickTimer = null;
       } else {
+        console.log('Single click---');
         this.clickTimer = setTimeout(() => {
           this.clickEvent.emit(_event);
           this.clickTimer = null;

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.ts
@@ -14,6 +14,7 @@ import { Component, Input, Output, EventEmitter, ViewEncapsulation, ElementRef, 
 import { TreeNode } from 'primeng/api';
 import { FileTreeNode } from '../../structures/child-event';
 import { FileNode } from '../../structures/file-node';
+import { UtilsService } from '../../services/utils.service';
 /**
  * [The tree component serves collapse/expansion of file/datasets]
  * @param  selector     [tree-root]
@@ -54,6 +55,8 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
   lastClickedNode: any = null;
   @ViewChild('fileExplorerPTree', { static: true }) fileExplorerTree: ElementRef;
 
+  constructor(private utils: UtilsService,){}
+
   /**
    * [nodeSelect provides the child folder click event to the parent file/folder tree tab]
    * @param  _event [click event]
@@ -69,31 +72,50 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
       return;
     }
 
-    console.log('---Event: ', _event);
+    const node = _event.node;
 
-    const isDirectory = _event.node?.directory;
-    const type = _event.node?.type;
+    const isUnixDirectory = this.utils.isUnixDirectory(node);
+    const isUnixFile = this.utils.isUnixFile(node);
+    const isPDSFolder = this.utils.isPDSDataset(node);
+    const isDatasetFile = this.utils.isDatasetFile(node);
 
-    if(isDirectory === undefined && type === undefined) {
+    console.log('isUnixDirectory', isUnixDirectory);
+    console.log('isUnixFile', isUnixFile);
+    console.log('isPDSFolder', isPDSFolder);
+    console.log('isDatasetFile', isDatasetFile);
+
+    if (!isUnixDirectory && !isUnixFile && !isPDSFolder && !isDatasetFile) {
       return;
     }
 
-    if (this.clickTimer && this.lastClickedNode === _event.node) {
+    if (this.isDoubleClick(node)) {
       this.resetClickDetection();
 
       // Indicates a file, dataset member, or sequential dataset where double-click has no additional effect
-      if((!type && !isDirectory) || (type === 'file') ) {
+      if( isUnixFile || isDatasetFile ) {
         this.clickEvent.emit(_event);
-        return;
+      } else {
+        this.dblClickEvent.emit(_event);
       }
-      this.dblClickEvent.emit(_event);
     } else {
-      this.lastClickedNode = _event.node;
-      this.clickTimer = setTimeout(() => {
-        this.resetClickDetection();
-        this.clickEvent.emit(_event);
-      }, this.doubleClickThreshold );
+      this.registerSingleClick(node, _event);
     }
+  }
+
+  registerSingleClick(node: any, _event: any): void {
+    this.lastClickedNode = node;
+    if (this.clickTimer) {
+      clearTimeout(this.clickTimer);
+    }
+
+    this.clickTimer = setTimeout(() => {
+      this.resetClickDetection();
+      this.clickEvent.emit(_event);
+    }, this.doubleClickThreshold);
+  }
+
+  isDoubleClick(node: any): boolean {
+    return this.clickTimer && this.lastClickedNode === node;
   }
 
   resetClickDetection() {

--- a/projects/zlux-file-explorer/src/lib/services/utils.service.ts
+++ b/projects/zlux-file-explorer/src/lib/services/utils.service.ts
@@ -11,7 +11,6 @@
 */
 
 import { Injectable } from '@angular/core';
-import { DatasetAttributes } from '../structures/editor-project';
 
 @Injectable()
 export class UtilsService {
@@ -23,6 +22,7 @@ export class UtilsService {
     }
     return path;
   }
+
   filePathEndCheck(path:string):string{
     if (path.slice(-1) !== '/') {
         return path + "/";
@@ -30,10 +30,22 @@ export class UtilsService {
     return path;
   }
 
-  isDatasetMigrated(attrs: DatasetAttributes): boolean {
-    return attrs.volser === 'MIGRAT' || attrs.volser === 'ARCIVE';
+  isUnixDirectory(node?: any): boolean {
+    return node?.data === "Folder" && node?.directory;
   }
 
+  isUnixFile(node?: any): boolean {
+    return node?.data === 'File' && !node?.directory;
+  }
+
+  isPDSDataset(node?: any): boolean {
+    return node?.data?.isDataset && node?.type === 'folder';
+  }
+
+  // Includes both, the sequential dataset and the dataset member 
+  isDatasetFile(node?: any): boolean {
+    return node?.data?.isDataset && node?.type==='file';
+  }
 }
 
 /*

--- a/projects/zlux-file-explorer/src/lib/services/utils.service.ts
+++ b/projects/zlux-file-explorer/src/lib/services/utils.service.ts
@@ -11,6 +11,7 @@
 */
 
 import { Injectable } from '@angular/core';
+import { DatasetAttributes } from '../structures/editor-project';
 
 @Injectable()
 export class UtilsService {
@@ -28,6 +29,10 @@ export class UtilsService {
         return path + "/";
     }
     return path;
+  }
+
+  isDatasetMigrated(attrs: DatasetAttributes): boolean {
+    return attrs.volser === 'MIGRAT' || attrs.volser === 'ARCIVE';
   }
 
   isUnixDirectory(node?: any): boolean {


### PR DESCRIPTION
This PR fixes the File Tree selection issue in the Editor. Now, double-clicking a file or dataset correctly opens it in the Editor.
It also prevents the error that occurred when double-clicking a node. Overall, it ensures consistent File Tree behavior across ZFM and Editor.