### PR TITLE
Create Member functionality to the MVS file explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "18.0.7",
         "@angular/platform-browser-dynamic": "18.0.7",
         "@angular/router": "18.0.7",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "primeng": "17.18.10",
         "rxjs": "7.8.1",
         "streamsaver": "2.0.6",
@@ -10660,9 +10660,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "18.0.7",
     "@angular/platform-browser-dynamic": "18.0.7",
     "@angular/router": "18.0.7",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "primeng": "17.18.10",
     "rxjs": "7.8.1",
     "streamsaver": "2.0.6",

--- a/projects/zlux-file-explorer/src/lib/components/create-file-modal/create-file-modal.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/create-file-modal/create-file-modal.component.ts
@@ -10,9 +10,6 @@
 */
 import { Component, Inject, EventEmitter } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { HttpClient } from '@angular/common/http';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { defaultSnackbarOptions } from '../../shared/snackbar-options';
 
 @Component({
   selector: 'create-file-modal',
@@ -30,8 +27,6 @@ export class CreateFileModal {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) data: any,
-    private http: HttpClient,
-    private snackBar: MatSnackBar,
   ) {
     const node = data.event;
     if (node.path) {
@@ -45,9 +40,7 @@ export class CreateFileModal {
   }
 
   createFile() {
-    const directoryPath: string = this.dirPath;
-    const path = directoryPath + '/' + this.fileName;
-    let onFileCreateResponse = new Map();
+    const onFileCreateResponse = new Map();
     onFileCreateResponse.set("pathAndName", this.dirPath + "/" + this.fileName);
     if (this.dirPath != this.folderPathObtainedFromNode) {
       //If the user changed the path obtained from the node or the node has never been opened...

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -41,7 +41,7 @@ Copyright Contributors to the Zowe Project.
       </button>
       }
       @if (memberName && !isValid) {
-      <mat-hint class="mat-error" style="color: #f44336;">Invalid member name. Must start with A-Z, #, $, or @; max 8 chars.</mat-hint>
+      <mat-hint class="mat-error" style="color: #f44336;">Invalid member name. Must start with A-Z, #, $, or &#64;; max 8 chars.</mat-hint>
       }
     </mat-form-field>
   </mat-dialog-content>

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -42,7 +42,7 @@ Copyright Contributors to the Zowe Project.
       }
       @if (memberName && !isValid) {
       <mat-hint class="mat-error" style="color: #f44336;">Invalid member name. Must start with A-Z, #, $, or &#64;; max 8 chars.</mat-hint>
-      }
+      }g
     </mat-form-field>
   </mat-dialog-content>
 

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -48,7 +48,7 @@ Copyright Contributors to the Zowe Project.
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button mat-button mat-dialog-close class="modal-mat-button create" 
+    <button mat-button class="modal-mat-button create" 
       (click)="createMember()" [disabled]="!isValid || creating">
       @if (creating) {
         <mat-icon class="spinning">sync</mat-icon> Creating...

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -34,6 +34,7 @@ Copyright Contributors to the Zowe Project.
       <input id="create-member-input" name="memberName" [pattern]="memberPattern" 
         matInput type="text" [ngModel]="memberName" 
         (ngModelChange)="memberName = $event.trim().toUpperCase()"
+        (keydown.enter)="isValid && !creating && createMember()"
         [disabled]="creating">
       @if (memberName) {
       <button class="modal-clear-button" mat-button matSuffix mat-icon-button tabindex="-1" aria-label="Clear"

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -33,10 +33,11 @@ Copyright Contributors to the Zowe Project.
     <mat-form-field style="margin-left: 5px;">
       <input id="create-member-input" name="memberName" [pattern]="memberPattern" 
         matInput type="text" [(ngModel)]="memberName" 
-        (input)="memberName = memberName.toUpperCase()">
+        (input)="memberName = memberName.trim().toUpperCase()"
+        [disabled]="creating">
       @if (memberName) {
       <button class="modal-clear-button" mat-button matSuffix mat-icon-button tabindex="-1" aria-label="Clear"
-        (click)="memberName=''">
+        (click)="memberName=''" [disabled]="creating">
         <mat-icon class="create-member-clear-icon">close</mat-icon>
       </button>
       }
@@ -48,7 +49,13 @@ Copyright Contributors to the Zowe Project.
 
   <mat-dialog-actions>
     <button mat-button mat-dialog-close class="modal-mat-button create" 
-      (click)="createMember()" [disabled]="!isValid">Create</button>
+      (click)="createMember()" [disabled]="!isValid || creating">
+      @if (creating) {
+        <mat-icon class="spinning">sync</mat-icon> Creating...
+      } @else {
+        Create
+      }
+    </button>
   </mat-dialog-actions>
 </div>
 <!--

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -33,7 +33,7 @@ Copyright Contributors to the Zowe Project.
     <mat-form-field style="margin-left: 5px;">
       <input id="create-member-input" name="memberName" [pattern]="memberPattern" 
         matInput type="text" [(ngModel)]="memberName" 
-        oninput="this.value = this.value.toUpperCase()">
+        (input)="memberName = memberName.toUpperCase()">
       @if (memberName) {
       <button class="modal-clear-button" mat-button matSuffix mat-icon-button tabindex="-1" aria-label="Clear"
         (click)="memberName=''">

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -32,8 +32,8 @@ Copyright Contributors to the Zowe Project.
     <label>Member Name:</label>
     <mat-form-field style="margin-left: 5px;">
       <input id="create-member-input" name="memberName" [pattern]="memberPattern" 
-        matInput type="text" [(ngModel)]="memberName" 
-        (input)="memberName = memberName.trim().toUpperCase()"
+        matInput type="text" [ngModel]="memberName" 
+        (ngModelChange)="memberName = $event.trim().toUpperCase()"
         [disabled]="creating">
       @if (memberName) {
       <button class="modal-clear-button" mat-button matSuffix mat-icon-button tabindex="-1" aria-label="Clear"

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -42,7 +42,7 @@ Copyright Contributors to the Zowe Project.
       }
       @if (memberName && !isValid) {
       <mat-hint class="mat-error" style="color: #f44336;">Invalid member name. Must start with A-Z, #, $, or &#64;; max 8 chars.</mat-hint>
-      }g
+      }
     </mat-form-field>
   </mat-dialog-content>
 

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.html
@@ -1,0 +1,62 @@
+<!--
+This program and the accompanying materials are
+made available under the terms of the Eclipse Public License v2.0 which accompanies
+this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
+-->
+<zlux-tab-trap hiddenIds="creatememberclearicon1" hiddenPos="2"></zlux-tab-trap>
+<div class="padding-1">
+  <div class="d-flex">
+    <div class="modal-icon-container">
+      <mat-icon style="font-size: 30px; position: absolute;">playlist_add</mat-icon>
+    </div>
+    <div>
+      <h2 mat-dialog-title class="modal-content-body">Create Member</h2>
+    </div>
+    <div>
+      <button mat-dialog-close class="close-dialog-btn"><i class="fa fa-close"></i></button>
+    </div>
+  </div>
+  
+  <mat-dialog-content>
+    <label>Dataset Name:</label>
+    <mat-form-field style="margin-left: 10px;">
+      <input matInput type="text" [value]="datasetName" disabled>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-content>
+    <label>Member Name:</label>
+    <mat-form-field style="margin-left: 5px;">
+      <input id="create-member-input" name="memberName" [pattern]="memberPattern" 
+        matInput type="text" [(ngModel)]="memberName" 
+        oninput="this.value = this.value.toUpperCase()">
+      @if (memberName) {
+      <button class="modal-clear-button" mat-button matSuffix mat-icon-button tabindex="-1" aria-label="Clear"
+        (click)="memberName=''">
+        <mat-icon class="create-member-clear-icon">close</mat-icon>
+      </button>
+      }
+      @if (memberName && !isValid) {
+      <mat-hint class="mat-error" style="color: #f44336;">Invalid member name. Must start with A-Z, #, $, or @; max 8 chars.</mat-hint>
+      }
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions>
+    <button mat-button mat-dialog-close class="modal-mat-button create" 
+      (click)="createMember()" [disabled]="!isValid">Create</button>
+  </mat-dialog-actions>
+</div>
+<!--
+    This program and the accompanying materials are
+    made available under the terms of the Eclipse Public License v2.0 which accompanies
+    this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Copyright Contributors to the Zowe Project.
+    -->

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
@@ -1,0 +1,30 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+.create-member-clear-icon {
+  font-size: 14px;
+  height: 5px;
+}
+
+.mat-mdc-dialog-content {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
@@ -19,6 +19,18 @@
   padding-bottom: 0px !important;
 }
 
+.spinning {
+  animation: spin 1s linear infinite;
+  font-size: 18px;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
@@ -14,6 +14,10 @@
   height: 5px;
 }
 
+#create-member-input {
+  text-transform: uppercase;
+}
+
 .mat-mdc-dialog-content {
   padding-top: 0px !important;
   padding-bottom: 0px !important;

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.scss
@@ -23,6 +23,18 @@
   padding-bottom: 0px !important;
 }
 
+mat-form-field {
+  overflow: visible;
+
+  .mat-mdc-form-field-subscript-wrapper {
+    overflow: visible;
+  }
+}
+
+.mat-error {
+  white-space: nowrap;
+}
+
 .spinning {
   animation: spin 1s linear infinite;
   font-size: 18px;

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.ts
@@ -22,6 +22,7 @@ export class CreateMemberModal {
   public datasetName: string = "";
   // Member name pattern: must start with A-Z, #, $, @; alphanumeric + #$@ allowed; max 8 chars total
   public memberPattern = /^[a-zA-Z#$@][a-zA-Z0-9#$@]{0,7}$/;
+  public creating = false;
   onCreate = new EventEmitter();
 
   constructor(
@@ -33,20 +34,22 @@ export class CreateMemberModal {
   }
 
   createMember() {
-    if (!this.memberName || !this.memberPattern.test(this.memberName)) {
+    const trimmed = (this.memberName || '').trim();
+    if (!trimmed || !this.memberPattern.test(trimmed)) {
       return;
     }
 
+    this.creating = true;
     let onCreateResponse = new Map();
-    onCreateResponse.set("memberName", this.memberName.toUpperCase());
+    onCreateResponse.set("memberName", trimmed.toUpperCase());
     onCreateResponse.set("datasetName", this.datasetName);
     this.onCreate.emit(onCreateResponse);
   }
 
   get isValid(): boolean {
-    return !!this.memberName && this.memberPattern.test(this.memberName);
+    const trimmed = (this.memberName || '').trim();
+    return !!trimmed && this.memberPattern.test(trimmed);
   }
-
 }
 
 /*

--- a/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/create-member-modal/create-member-modal.component.ts
@@ -1,0 +1,60 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+import { Component, Inject, EventEmitter } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'create-member-modal',
+  templateUrl: './create-member-modal.component.html',
+  styleUrls: ['./create-member-modal.component.scss',
+    '../../shared/modal.component.scss'],
+})
+export class CreateMemberModal {
+  public memberName: string = "";
+  public datasetName: string = "";
+  // Member name pattern: must start with A-Z, #, $, @; alphanumeric + #$@ allowed; max 8 chars total
+  public memberPattern = /^[a-zA-Z#$@][a-zA-Z0-9#$@]{0,7}$/;
+  onCreate = new EventEmitter();
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) data: any,
+  ) {
+    if (data && data.datasetName) {
+      this.datasetName = data.datasetName;
+    }
+  }
+
+  createMember() {
+    if (!this.memberName || !this.memberPattern.test(this.memberName)) {
+      return;
+    }
+
+    let onCreateResponse = new Map();
+    onCreateResponse.set("memberName", this.memberName.toUpperCase());
+    onCreateResponse.set("datasetName", this.datasetName);
+    this.onCreate.emit(onCreateResponse);
+  }
+
+  get isValid(): boolean {
+    return !!this.memberName && this.memberPattern.test(this.memberName);
+  }
+
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -64,6 +64,12 @@
 .file-tree-utilities {
   overflow: hidden;
   border: 1px solid #464646;
+  padding: 4px 6px;
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
 }
 
 .filebrowsermvs-loading-icon {
@@ -73,9 +79,10 @@
 }
 
 .filebrowser-icon {
-  margin-right: 9px;
-  float: right;
   cursor: pointer;
+  font-size: 14px;
+  padding: 2px;
+  line-height: 1;
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -68,8 +68,8 @@
   min-height: 26px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 5px;
 }
 
 .filebrowsermvs-loading-icon {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -81,8 +81,18 @@
 .filebrowser-icon {
   cursor: pointer;
   font-size: 15px;
-  padding: 2px;
-  line-height: 1;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  position: relative;
+}
+
+.filebrowser-icon::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -68,8 +68,8 @@
   min-height: 26px;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
+  justify-content: center;
+  gap: 10px;
 }
 
 .filebrowsermvs-loading-icon {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -14,7 +14,7 @@
 }
 
 .filebrowsermvs-search {
-  width: fit-content;
+  width: auto;
   min-width: 250px;
   margin-left: 5px;
   display: flex;
@@ -37,9 +37,9 @@
 
 .filebrowser-nav-back {
   cursor: pointer;
-  font-size: 16px;
+  font-size: 20px;
   color: #d4d4d4;
-  padding: 0 6px;
+  padding: 0 8px;
   display: flex;
   align-items: center;
 }
@@ -50,13 +50,13 @@
 
 .filebrowser-tree-wrapper {
   flex: 1;
-  overflow: auto;
   min-height: 0;
+  position: relative;
 }
 
-.filebrowser-tree-wrapper .p-tree-container {
-  overflow: visible !important;
-  height: auto !important;
+.filebrowser-tree-wrapper tree-root {
+  position: absolute;
+  inset: 0;
 }
 
 .p-tree-empty-message {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -17,7 +17,8 @@
   width: fit-content;
   min-width: 250px;
   margin-left: 5px;
-  display: inline-block;
+  display: flex;
+  align-items: center;
   height: 40px;
 }
 
@@ -34,12 +35,28 @@
   flex-grow: 2;
 }
 
-.filebrowsermvs-pointer-logo {
-  content: url('../../../assets/explorer-uparrow.png');
-  width: 20px;
-  height: 20px;
-  filter: brightness(3);
+.filebrowser-nav-back {
   cursor: pointer;
+  font-size: 16px;
+  color: #d4d4d4;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+}
+
+.filebrowser-nav-back:hover {
+  color: #ffffff;
+}
+
+.filebrowser-tree-wrapper {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.filebrowser-tree-wrapper .p-tree-container {
+  overflow: visible !important;
+  height: auto !important;
 }
 
 .p-tree-empty-message {
@@ -70,12 +87,6 @@
   align-items: center;
   justify-content: flex-end;
   gap: 5px;
-}
-
-.filebrowsermvs-loading-icon {
-  margin-left: 8px !important;
-  font-size: large !important;
-
 }
 
 .filebrowser-icon {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -15,11 +15,12 @@
 
 .filebrowsermvs-search {
   width: auto;
-  min-width: 250px;
+  min-width: 0;
   margin-left: 5px;
   display: flex;
   align-items: center;
   height: 40px;
+  overflow: hidden;
 }
 
 .filebrowsermvs-search-input {
@@ -57,6 +58,8 @@
 .filebrowser-tree-wrapper tree-root {
   position: absolute;
   inset: 0;
+  display: block;
+  overflow: hidden;
 }
 
 .p-tree-empty-message {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -80,13 +80,13 @@
 
 .filebrowser-icon {
   cursor: pointer;
-  font-size: 14px;
+  font-size: 15px;
   padding: 2px;
   line-height: 1;
 }
 
 .special-utility {
-  margin-left: 9px;
+  margin-left: 0;
 }
 
 /*

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -16,12 +16,14 @@
 .searchRowFlex {
   display: flex;
   flex-direction: row;
+  width: 100%;
 }
 
 .filebrowsermvs-search {
-  width: auto;
+  width: 100%;
   min-width: 0;
-  margin-left: 5px;
+  margin: 0 0 2px 0;
+  padding-left: 5px;
   display: flex;
   align-items: center;
   height: 40px;

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.css
@@ -8,6 +8,11 @@
   Copyright Contributors to the Zowe Project.
 */
 
+:host {
+  display: block;
+  height: 100%;
+}
+
 .searchRowFlex {
   display: flex;
   flex-direction: row;
@@ -59,7 +64,8 @@
   position: absolute;
   inset: 0;
   display: block;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .p-tree-empty-message {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
@@ -40,12 +40,10 @@ Copyright Contributors to the Zowe Project.
   <div class="fa fa-refresh filebrowsermvs-loading-icon" title="Refresh dataset list" (click)="updateTreeView(path);"
     [hidden]="isLoading" style="margin-left: 9px; cursor: pointer;"></div>
   <div class="file-tree-utilities">
-    <div class="fa fa-minus-square-o filebrowseruss-collapse-icon" title="Collapse Folders in Explorer"
-      (click)="collapseTree();" style="margin-right: 9px; float:right; cursor: pointer;"></div>
-    <div class="fa fa-trash-o filebrowseruss-delete-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"
-      style="margin-right: 9px; float:right; cursor: pointer;"></div>
-    <div class="fa fa-plus" title="Create new dataset" (click)="createDatasetDialog()"
-      style="margin-right: 9px; float:right; cursor: pointer;"></div>
+    <div class="fa fa-minus-square-o filebrowser-icon" title="Collapse Folders in Explorer"
+      (click)="collapseTree();"></div>
+    <div class="fa fa-trash-o filebrowser-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"></div>
+    <div class="fa fa-plus filebrowser-icon" title="Create new dataset" (click)="createDatasetDialog()"></div>
     <div class="fa fa-eraser filebrowser-icon special-utility" title="Clear Search History"
       (click)="clearSearchHistory();"></div>
   </div>

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 -->
 
-<div style="height: 100%">
+<div style="height: 100%; display: flex; flex-direction: column; overflow: hidden;">
 
   <!-- Tabs, searchbar, and loading indicator -->
   @if (showUpArrow) {
@@ -37,9 +37,9 @@ Copyright Contributors to the Zowe Project.
   </div>
 
   <div class="fa fa-spinner fa-spin filebrowsermvs-loading-icon" [hidden]="!isLoading"></div>
-  <div class="fa fa-refresh filebrowsermvs-loading-icon" title="Refresh dataset list" (click)="updateTreeView(path);"
-    [hidden]="isLoading" style="margin-left: 9px; cursor: pointer;"></div>
   <div class="file-tree-utilities">
+    <div class="fa fa-refresh filebrowser-icon" title="Refresh dataset list" (click)="updateTreeView(path);"
+      [hidden]="isLoading"></div>
     <div class="fa fa-minus-square-o filebrowser-icon" title="Collapse Folders in Explorer"
       (click)="collapseTree();"></div>
     <div class="fa fa-trash-o filebrowser-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"></div>
@@ -48,7 +48,7 @@ Copyright Contributors to the Zowe Project.
       (click)="clearSearchHistory();"></div>
   </div>
   <!-- Main tree -->
-  <div [hidden]="hideExplorer" style="height: 100%;">
+  <div [hidden]="hideExplorer" style="flex: 1; overflow: hidden; min-height: 0;">
     <tree-root 
       [treeData]="data" 
       (clickEvent)="onNodeClick($event)" 

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.html
@@ -11,13 +11,12 @@ Copyright Contributors to the Zowe Project.
 <div style="height: 100%; display: flex; flex-direction: column; overflow: hidden;">
 
   <!-- Tabs, searchbar, and loading indicator -->
-  @if (showUpArrow) {
-  <img data-toggle="tooltip" class="filebrowsermvs-pointer-logo" title="Go up to the parent level" (click)="levelUp()"
-    [ngStyle]="treeStyle" tabindex="0" (keydown.enter)="levelUp()" />
-  }
-
   <div class="filebrowsermvs-search" [ngStyle]="searchStyle">
     <div class="searchRowFlex">
+      @if (showUpArrow) {
+      <div class="fa fa-arrow-left filebrowser-nav-back" title="Go up to the parent level" (click)="levelUp()"
+        tabindex="0" (keydown.enter)="levelUp()"></div>
+      }
       <input [(ngModel)]="path" list="searchMVSHistory" placeholder="Enter a dataset query..."
         class="filebrowsermvs-search-input" (keydown.enter)="updateTreeView(path);" [ngStyle]="inputStyle">
       <!-- TODO: make search history a directive to use in both uss and mvs-->
@@ -36,10 +35,10 @@ Copyright Contributors to the Zowe Project.
     </div>
   </div>
 
-  <div class="fa fa-spinner fa-spin filebrowsermvs-loading-icon" [hidden]="!isLoading"></div>
   <div class="file-tree-utilities">
     <div class="fa fa-refresh filebrowser-icon" title="Refresh dataset list" (click)="updateTreeView(path);"
       [hidden]="isLoading"></div>
+    <div class="fa fa-spinner fa-spin filebrowser-icon" [hidden]="!isLoading"></div>
     <div class="fa fa-minus-square-o filebrowser-icon" title="Collapse Folders in Explorer"
       (click)="collapseTree();"></div>
     <div class="fa fa-trash-o filebrowser-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"></div>
@@ -48,7 +47,7 @@ Copyright Contributors to the Zowe Project.
       (click)="clearSearchHistory();"></div>
   </div>
   <!-- Main tree -->
-  <div [hidden]="hideExplorer" style="flex: 1; overflow: hidden; min-height: 0;">
+  <div [hidden]="hideExplorer" class="filebrowser-tree-wrapper">
     <tree-root 
       [treeData]="data" 
       (clickEvent)="onNodeClick($event)" 

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -337,7 +337,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
             createMemberRef.componentInstance.creating = false;
             const raw = error?.error;
             const errorMessage = (typeof raw === 'string') ? raw
-              : raw?.msg || raw?.message || JSON.stringify(raw) || `Status ${error?.status ?? 'unknown'}`;
+              : raw?.error || raw?.msg || raw?.message || JSON.stringify(raw) || `Status ${error?.status ?? 'unknown'}`;
             this.snackBar.open(`Failed to create member '${memberName}': ${errorMessage}`,
               'Dismiss', longSnackbarOptions);
           }

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -315,9 +315,9 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
     }
 
     const createMemberConfig = new MatDialogConfig();
+    createMemberConfig.width = '600px';
     createMemberConfig.data = {
-      datasetName,
-      width: '600px'
+      datasetName
     };
 
     let createMemberRef: MatDialogRef<CreateMemberModal> = this.dialog.open(CreateMemberModal, createMemberConfig);
@@ -328,6 +328,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
         .pipe(take(1))
         .subscribe({
           next: _resp => {
+            createMemberRef.close();
             this.snackBar.open(`Member '${memberName}' created successfully in '${selectedDatasetName}'.`,
               'Dismiss', quickSnackbarOptions);
             this.updateTreeView(this.path);

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -12,7 +12,7 @@
 
 
 import { Component, ElementRef, OnInit, ViewEncapsulation, OnDestroy, Input, EventEmitter, Output, Inject, Optional, ViewChild } from '@angular/core';
-import { take, takeUntil, finalize, debounceTime } from 'rxjs/operators';
+import { take, finalize, debounceTime } from 'rxjs/operators';
 import { ProjectStructure, DatasetAttributes, Member } from '../../structures/editor-project';
 import { Angular2InjectionTokens, Angular2PluginWindowActions, ContextMenuItem } from '../../../pluginlib/inject-resources';
 import { DownloaderService } from '../../services/downloader.service';
@@ -315,26 +315,28 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
     }
 
     const createMemberConfig = new MatDialogConfig();
-    createMemberConfig.width = '600px';
     createMemberConfig.data = {
-      datasetName
+      datasetName,
+      width: '600px'
     };
 
     let createMemberRef: MatDialogRef<CreateMemberModal> = this.dialog.open(CreateMemberModal, createMemberConfig);
-    createMemberRef.componentInstance.onCreate.pipe(takeUntil(createMemberRef.afterClosed())).subscribe(onCreateResponse => {
+    createMemberRef.componentInstance.onCreate.subscribe(onCreateResponse => {
       const memberName = onCreateResponse.get('memberName');
       const selectedDatasetName = onCreateResponse.get('datasetName');
       this.datasetService.createMember(selectedDatasetName, memberName)
         .pipe(take(1))
         .subscribe({
           next: _resp => {
-            createMemberRef.close();
             this.snackBar.open(`Member '${memberName}' created successfully in '${selectedDatasetName}'.`,
               'Dismiss', quickSnackbarOptions);
+            createMemberRef.close();
             this.updateTreeView(this.path);
           },
           error: error => {
-            const errorMessage = error?.error?.msg || error?.error || `Status ${error?.status ?? 'unknown'}`;
+            const raw = error?.error;
+            const errorMessage = (typeof raw === 'string') ? raw
+              : raw?.msg || raw?.message || JSON.stringify(raw) || `Status ${error?.status ?? 'unknown'}`;
             this.snackBar.open(`Failed to create member '${memberName}': ${errorMessage}`,
               'Dismiss', longSnackbarOptions);
           }
@@ -343,31 +345,27 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
   }
 
   private isPartitionedDataset(node: any): boolean {
-    // A node with type 'folder' in the MVS tree is typically a partitioned dataset,
-    // but exclude VSAM clusters which may also appear as folders
-    if (node?.type === 'folder') {
-      const dsorg = node?.data?.datasetAttrs?.dsorg;
-      if (dsorg?.isVSAM) {
-        return false;
-      }
-      return true;
-    }
-
+    // Check dsorg metadata first — more reliable than tree node type
     const dsorg = node?.data?.datasetAttrs?.dsorg;
-    if (!dsorg) {
+    if (dsorg) {
+      const organization = dsorg.organization;
+      if (typeof organization === 'string') {
+        const upper = organization.toUpperCase();
+        // Server returns 'partitioned' or formatted as 'PO'/'PO-E'
+        if (upper === 'PARTITIONED' || upper.startsWith('PO')) {
+          return true;
+        }
+      }
+      if (dsorg.isPDSDir || dsorg.isPDSE) {
+        return true;
+      }
+      // If dsorg exists but doesn't indicate PDS, it's not partitioned
       return false;
     }
 
-    const organization = dsorg.organization;
-    if (typeof organization === 'string') {
-      const upper = organization.toUpperCase();
-      // Server returns 'partitioned' or formatted as 'PO'/'PO-E'
-      if (upper === 'PARTITIONED' || upper.startsWith('PO')) {
-        return true;
-      }
-    }
-
-    if (dsorg.isPDSDir || dsorg.isPDSE) {
+    // Only trust 'folder' type if we have no dsorg metadata (fallback)
+    // This avoids showing "Create Member" for migrated/unknown datasets
+    if (node?.type === 'folder') {
       return true;
     }
 
@@ -917,42 +915,46 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
     let saveRef = this.dialog.open(CreateDatasetModal, dsCreateConfig);
 
     saveRef.afterClosed().subscribe(attributes => {
+      if (!attributes) {
+        return;
+      }
       if (attributes.datasetNameType == 'LIBRARY') {
         attributes.datasetNameType = 'PDSE';
       }
-      if (attributes) {
-        const datasetAttributes = {
-          ndisp: 'CATALOG',
-          status: 'NEW',
-          space: attributes.allocationUnit,
-          dsorg: attributes.organization,
-          lrecl: parseInt(attributes.recordLength),
-          recfm: attributes.recordFormat,
-          dir: parseInt(attributes.directoryBlocks),
-          prime: parseInt(attributes.primarySpace),
-          secnd: parseInt(attributes.secondarySpace),
-          dsnt: attributes.datasetNameType,
-          close: 'true'
-        }
+      const datasetAttributes = {
+        ndisp: 'CATALOG',
+        status: 'NEW',
+        space: attributes.allocationUnit,
+        dsorg: attributes.organization,
+        lrecl: parseInt(attributes.recordLength),
+        recfm: attributes.recordFormat,
+        dir: parseInt(attributes.directoryBlocks),
+        prime: parseInt(attributes.primarySpace),
+        secnd: parseInt(attributes.secondarySpace),
+        dsnt: attributes.datasetNameType,
+        close: 'true'
+      };
 
-        if (attributes.averageRecordUnit) {
-          datasetAttributes['avgr'] = attributes.averageRecordUnit;
-        }
-        if (attributes.blockSize) {
-          datasetAttributes['blksz'] = parseInt(attributes.blockSize);
-        }
-
-        this.datasetService.createDataset(datasetAttributes, attributes.name).subscribe({
-          next: resp => {
-            this.snackBar.open(`Dataset: ${attributes.name} created successfully.`, 'Dismiss', quickSnackbarOptions);
-            this.createDataset.emit({ status: 'success', name: attributes.name, org: attributes.organization, initData: dsCreateConfig.data.data });
-          },
-          error: error => {
-            this.snackBar.open(`Failed to create the dataset: ${error.error}`, 'Dismiss', longSnackbarOptions);
-            this.createDataset.emit({ status: 'error', error: error.error, name: attributes.name });
-          }
-        });
+      if (attributes.averageRecordUnit) {
+        datasetAttributes['avgr'] = attributes.averageRecordUnit;
       }
+      if (attributes.blockSize) {
+        datasetAttributes['blksz'] = parseInt(attributes.blockSize);
+      }
+
+      this.datasetService.createDataset(datasetAttributes, attributes.name).subscribe({
+        next: resp => {
+          this.snackBar.open(`Dataset: ${attributes.name} created successfully.`, 'Dismiss', quickSnackbarOptions);
+          this.createDataset.emit({ status: 'success', name: attributes.name, org: attributes.organization, initData: dsCreateConfig.data.data });
+        },
+        error: error => {
+          const raw = error?.error;
+          const errorMessage = (typeof raw === 'string') ? raw
+            : raw?.msg || raw?.message || JSON.stringify(raw) || `Status ${error?.status ?? 'unknown'}`;
+          this.snackBar.open(`Failed to create the dataset: ${errorMessage}`, 'Dismiss', longSnackbarOptions);
+          this.createDataset.emit({ status: 'error', error: errorMessage, name: attributes.name });
+        }
+      });
     });
   }
 

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -334,6 +334,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
             this.updateTreeView(this.path);
           },
           error: error => {
+            createMemberRef.componentInstance.creating = false;
             const raw = error?.error;
             const errorMessage = (typeof raw === 'string') ? raw
               : raw?.msg || raw?.message || JSON.stringify(raw) || `Status ${error?.status ?? 'unknown'}`;

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -31,6 +31,7 @@ import { SearchHistoryService } from '../../services/searchHistoryService';
 import { UtilsService } from '../../services/utils.service';
 import { DatasetCrudService } from '../../services/dataset.crud.service';
 import { CreateDatasetModal } from '../create-dataset-modal/create-dataset-modal.component';
+import { CreateMemberModal } from '../create-member-modal/create-member-modal.component';
 import { TreeNode } from 'primeng/api';
 /* TODO: re-implement to add fetching of previously opened tree view data
 import { PersistentDataService } from '../../services/persistentData.service'; */
@@ -248,6 +249,11 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
         }
       },
       {
+        text: "Create Member", action: () => {
+          this.showCreateMemberDialog(this.rightClickedFile);
+        }
+      },
+      {
         text: "Properties", action: () => {
           this.showPropertiesDialog(this.rightClickedFile);
         }
@@ -287,6 +293,79 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
         this.deleteNonVsamDataset(rightClickedFile);
       }
     });
+  }
+
+  showCreateMemberDialog(rightClickedFile: any) {
+    const datasetName = rightClickedFile?.data?.path;
+    if (!datasetName) {
+      this.snackBar.open('Unable to determine dataset path for member creation.',
+        'Dismiss', defaultSnackbarOptions);
+      return;
+    }
+
+    if (!this.isPartitionedDataset(rightClickedFile)) {
+      this.snackBar.open(`Cannot create member in non-partitioned dataset '${datasetName}'.`,
+        'Dismiss', defaultSnackbarOptions);
+      return;
+    }
+
+    if (this.checkIfInDeletionQueueAndMessage(datasetName,
+      'Cannot create a member inside a dataset queued for deletion.') == true) {
+      return;
+    }
+
+    const createMemberConfig = new MatDialogConfig();
+    createMemberConfig.data = {
+      datasetName,
+      width: '600px'
+    };
+
+    let createMemberRef: MatDialogRef<CreateMemberModal> = this.dialog.open(CreateMemberModal, createMemberConfig);
+    createMemberRef.componentInstance.onCreate.subscribe(onCreateResponse => {
+      const memberName = onCreateResponse.get('memberName');
+      const selectedDatasetName = onCreateResponse.get('datasetName');
+      this.datasetService.createMember(selectedDatasetName, memberName)
+        .pipe(take(1))
+        .subscribe({
+          next: _resp => {
+            this.snackBar.open(`Member '${memberName}' created successfully in '${selectedDatasetName}'.`,
+              'Dismiss', quickSnackbarOptions);
+            this.updateTreeView(this.path);
+          },
+          error: error => {
+            const errorMessage = error?.error?.msg || error?.error || `Status ${error?.status ?? 'unknown'}`;
+            this.snackBar.open(`Failed to create member '${memberName}': ${errorMessage}`,
+              'Dismiss', longSnackbarOptions);
+          }
+        });
+    });
+  }
+
+  private isPartitionedDataset(node: any): boolean {
+    // A node with type 'folder' in the MVS tree is always a partitioned dataset
+    if (node?.type === 'folder') {
+      return true;
+    }
+
+    const dsorg = node?.data?.datasetAttrs?.dsorg;
+    if (!dsorg) {
+      return false;
+    }
+
+    const organization = dsorg.organization;
+    if (typeof organization === 'string') {
+      const upper = organization.toUpperCase();
+      // Server returns 'partitioned' or formatted as 'PO'/'PO-E'
+      if (upper === 'PARTITIONED' || upper.startsWith('PO')) {
+        return true;
+      }
+    }
+
+    if (dsorg.isPDSDir || dsorg.isPDSE) {
+      return true;
+    }
+
+    return false;
   }
 
   deleteNonVsamDataset(rightClickedFile: any): void {
@@ -599,7 +678,9 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
       rightClickProperties = this.rightClickPropertiesDatasetFile;
     }
     else {
-      rightClickProperties = this.rightClickPropertiesDatasetFolder;
+      rightClickProperties = this.rightClickPropertiesDatasetFolder.filter(item => {
+        return item.text !== 'Create Member' || this.isPartitionedDataset(node);
+      });
     }
     if (this.windowActions) {
       let didContextMenuSpawn = this.windowActions.spawnContextMenu(event.originalEvent.clientX, event.originalEvent.clientY, rightClickProperties, true);

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -315,9 +315,9 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
     }
 
     const createMemberConfig = new MatDialogConfig();
+    createMemberConfig.width = '600px';
     createMemberConfig.data = {
-      datasetName,
-      width: '600px'
+      datasetName
     };
 
     let createMemberRef: MatDialogRef<CreateMemberModal> = this.dialog.open(CreateMemberModal, createMemberConfig);

--- a/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowsermvs/filebrowsermvs.component.ts
@@ -12,7 +12,7 @@
 
 
 import { Component, ElementRef, OnInit, ViewEncapsulation, OnDestroy, Input, EventEmitter, Output, Inject, Optional, ViewChild } from '@angular/core';
-import { take, finalize, debounceTime } from 'rxjs/operators';
+import { take, takeUntil, finalize, debounceTime } from 'rxjs/operators';
 import { ProjectStructure, DatasetAttributes, Member } from '../../structures/editor-project';
 import { Angular2InjectionTokens, Angular2PluginWindowActions, ContextMenuItem } from '../../../pluginlib/inject-resources';
 import { DownloaderService } from '../../services/downloader.service';
@@ -321,7 +321,7 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
     };
 
     let createMemberRef: MatDialogRef<CreateMemberModal> = this.dialog.open(CreateMemberModal, createMemberConfig);
-    createMemberRef.componentInstance.onCreate.subscribe(onCreateResponse => {
+    createMemberRef.componentInstance.onCreate.pipe(takeUntil(createMemberRef.afterClosed())).subscribe(onCreateResponse => {
       const memberName = onCreateResponse.get('memberName');
       const selectedDatasetName = onCreateResponse.get('datasetName');
       this.datasetService.createMember(selectedDatasetName, memberName)
@@ -343,8 +343,13 @@ export class FileBrowserMVSComponent implements OnInit, OnDestroy {
   }
 
   private isPartitionedDataset(node: any): boolean {
-    // A node with type 'folder' in the MVS tree is always a partitioned dataset
+    // A node with type 'folder' in the MVS tree is typically a partitioned dataset,
+    // but exclude VSAM clusters which may also appear as folders
     if (node?.type === 'folder') {
+      const dsorg = node?.data?.datasetAttrs?.dsorg;
+      if (dsorg?.isVSAM) {
+        return false;
+      }
       return true;
     }
 

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -90,8 +90,8 @@
   min-height: 26px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 5px;
 }
 
 .filebrowser-icon {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -9,7 +9,7 @@
 */
 
 .filebrowseruss-search {
-  width: fit-content;
+  width: auto;
   min-width: 250px;
   margin-left: 5px;
   display: flex;
@@ -69,9 +69,9 @@
 
 .filebrowser-nav-back {
   cursor: pointer;
-  font-size: 16px;
+  font-size: 20px;
   color: #d4d4d4;
-  padding: 0 6px;
+  padding: 0 8px;
   display: flex;
   align-items: center;
 }
@@ -82,13 +82,13 @@
 
 .filebrowser-tree-wrapper {
   flex: 1;
-  overflow: auto;
   min-height: 0;
+  position: relative;
 }
 
-.filebrowser-tree-wrapper .p-tree-container {
-  overflow: visible !important;
-  height: auto !important;
+.filebrowser-tree-wrapper tree-root {
+  position: absolute;
+  inset: 0;
 }
 
 .filebrowseruss-node-deleting {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -96,13 +96,13 @@
 
 .filebrowser-icon {
   cursor: pointer;
-  font-size: 14px;
+  font-size: 15px;
   padding: 2px;
   line-height: 1;
 }
 
 .special-utility {
-  margin-left: 9px;
+  margin-left: 0;
 }
 
 

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -16,7 +16,7 @@
 .filebrowseruss-search {
   width: auto;
   min-width: 0;
-  margin-left: 5px;
+  margin: 0 5px 2px 5px;
   display: flex;
   align-items: center;
   height: 40px;
@@ -64,13 +64,6 @@
   outline: none;
   border: 1px solid rgb(161, 160, 160);
   border-radius: 3px;
-}
-
-.filebrowseruss-dialog-menu {
-  background: white;
-  padding: 0px;
-  height: auto;
-  width: auto;
 }
 
 .filebrowser-nav-back {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -10,11 +10,12 @@
 
 .filebrowseruss-search {
   width: auto;
-  min-width: 250px;
+  min-width: 0;
   margin-left: 5px;
   display: flex;
   align-items: center;
   height: 40px;
+  overflow: hidden;
 }
 
 .filebrowseruss-search-input {
@@ -89,6 +90,8 @@
 .filebrowser-tree-wrapper tree-root {
   position: absolute;
   inset: 0;
+  display: block;
+  overflow: hidden;
 }
 
 .filebrowseruss-node-deleting {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -12,7 +12,8 @@
   width: fit-content;
   min-width: 250px;
   margin-left: 5px;
-  display: inline-block;
+  display: flex;
+  align-items: center;
   height: 40px;
 }
 
@@ -66,21 +67,32 @@
   width: auto;
 }
 
-.filebrowseruss-pointer-logo {
-  content: url('../../../assets/explorer-uparrow.png');
-  width: 20px;
-  height: 20px;
-  filter: brightness(3);
+.filebrowser-nav-back {
   cursor: pointer;
+  font-size: 16px;
+  color: #d4d4d4;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+}
+
+.filebrowser-nav-back:hover {
+  color: #ffffff;
+}
+
+.filebrowser-tree-wrapper {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.filebrowser-tree-wrapper .p-tree-container {
+  overflow: visible !important;
+  height: auto !important;
 }
 
 .filebrowseruss-node-deleting {
   opacity: .5;
-}
-
-.filebrowseruss-loading-icon {
-  margin-left: 8px !important;
-  font-size: large !important;
 }
 
 .file-tree-utilities {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -99,6 +99,11 @@
   font-size: 15px;
   padding: 2px;
   line-height: 1;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -8,6 +8,11 @@
   Copyright Contributors to the Zowe Project.
 */
 
+:host {
+  display: block;
+  height: 100%;
+}
+
 .filebrowseruss-search {
   width: auto;
   min-width: 0;
@@ -91,7 +96,8 @@
   position: absolute;
   inset: 0;
   display: block;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .filebrowseruss-node-deleting {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -90,8 +90,8 @@
   min-height: 26px;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
+  justify-content: center;
+  gap: 10px;
 }
 
 .filebrowser-icon {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -86,12 +86,18 @@
 .file-tree-utilities {
   overflow: hidden;
   border: 1px solid #464646;
+  padding: 6px 4px;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .filebrowser-icon {
   margin-right: 9px;
-  float: right;
   cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -97,13 +97,18 @@
 .filebrowser-icon {
   cursor: pointer;
   font-size: 15px;
-  padding: 2px;
-  line-height: 1;
   width: 20px;
   height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  line-height: 20px;
+  text-align: center;
+  position: relative;
+}
+
+.filebrowser-icon::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -91,13 +91,14 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 6px;
+  gap: 4px;
 }
 
 .filebrowser-icon {
   cursor: pointer;
-  font-size: 13px;
+  font-size: 14px;
   padding: 2px;
+  line-height: 1;
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.css
@@ -86,18 +86,18 @@
 .file-tree-utilities {
   overflow: hidden;
   border: 1px solid #464646;
-  padding: 6px 4px;
-  min-height: 28px;
+  padding: 4px 6px;
+  min-height: 26px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 6px;
 }
 
 .filebrowser-icon {
-  margin-right: 9px;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 4px;
+  font-size: 13px;
+  padding: 2px;
 }
 
 .special-utility {

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 -->
 
-<div style="height: 100%;">
+<div style="height: 100%; display: flex; flex-direction: column; overflow: hidden;">
 
   <!-- Tabs, searchbar, and loading indicator -->
   @if (showUpArrow) {
@@ -28,9 +28,9 @@ Copyright Contributors to the Zowe Project.
     </datalist>
   </div>
   <div class="fa fa-spinner fa-spin filebrowseruss-loading-icon" [hidden]="!isLoading" style="margin-left: 9px;"></div>
-  <div class="fa fa-refresh filebrowseruss-loading-icon" title="Refresh whole directory"
-    (click)="displayTree(path, false);" [hidden]="isLoading" style="margin-left: 9px; cursor: pointer;"></div>
   <div class="file-tree-utilities">
+    <div class="fa fa-refresh filebrowser-icon" title="Refresh whole directory"
+      (click)="displayTree(path, false);" [hidden]="isLoading"></div>
     <div class="fa fa-minus-square-o filebrowser-icon" title="Collapse Folders in Explorer" (click)="collapseTree();">
     </div>
     <div class="fa fa-trash-o filebrowser-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"></div>
@@ -45,7 +45,7 @@ Copyright Contributors to the Zowe Project.
   </div>
 
   <!-- Main tree -->
-  <div [hidden]="hideExplorer" style="height: 100%;">
+  <div [hidden]="hideExplorer" style="flex: 1; overflow: hidden; min-height: 0;">
     <tree-root 
       [treeData]="data"
       (clickEvent)="onNodeClick($event)"

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -37,7 +37,7 @@ Copyright Contributors to the Zowe Project.
       (click)="showCreateFolderDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
     </div>
     <div class="fa fa-plus filebrowser-icon" title="New File"
-      (click)="newFileClick.emit(selectedNode || '')">
+      (click)="newFileClick.emit({ path: path, existingNames: data })">
     </div>
     <div class="fa fa-eraser filebrowser-icon special-utility" title="Clear Search History"
       (click)="clearSearchHistory();"></div>

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -37,7 +37,7 @@ Copyright Contributors to the Zowe Project.
     <div class="fa fa-folder-o filebrowser-icon" title="Create New Folder"
       (click)="showCreateFolderDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
     </div>
-    <div class="fa fa-plus filebrowser-icon" title="New File" style="font-size: 14px;"
+    <div class="fa fa-plus filebrowser-icon" title="New File"
       (click)="newFileClick.emit(selectedNode || '')">
     </div>
     <div class="fa fa-eraser filebrowser-icon special-utility" title="Clear Search History"

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -37,6 +37,9 @@ Copyright Contributors to the Zowe Project.
     <div class="fa fa-folder-o filebrowser-icon" title="Create New Folder"
       (click)="showCreateFolderDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
     </div>
+    <div class="fa fa-file-o filebrowser-icon" title="Create New File"
+      (click)="showCreateFileDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
+    </div>
     <div class="fa fa-eraser filebrowser-icon special-utility" title="Clear Search History"
       (click)="clearSearchHistory();"></div>
   </div>

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -11,12 +11,11 @@ Copyright Contributors to the Zowe Project.
 <div style="height: 100%; display: flex; flex-direction: column; overflow: hidden;">
 
   <!-- Tabs, searchbar, and loading indicator -->
-  @if (showUpArrow) {
-  <img data-toggle="tooltip" class="filebrowseruss-pointer-logo" title="Go up to the parent level" (click)="levelUp()"
-    [ngStyle]="treeStyle" tabindex="0" (keydown.enter)="levelUp()">
-  }
-
   <div class="filebrowseruss-search" [ngStyle]="searchStyle">
+    @if (showUpArrow) {
+    <div class="fa fa-arrow-left filebrowser-nav-back" title="Go up to the parent level" (click)="levelUp()"
+      tabindex="0" (keydown.enter)="levelUp()"></div>
+    }
     <input #pathInputUSS [(ngModel)]="path" list="searchUSSHistory" placeholder="Enter an absolute path..."
       [ngStyle]="inputStyle" class="filebrowseruss-search-input" (keydown.enter)="displayTree(path, false);"
       [disabled]="isLoading" (ngModelChange)="checkPathSlash($event)">
@@ -27,10 +26,10 @@ Copyright Contributors to the Zowe Project.
       }
     </datalist>
   </div>
-  <div class="fa fa-spinner fa-spin filebrowseruss-loading-icon" [hidden]="!isLoading" style="margin-left: 9px;"></div>
   <div class="file-tree-utilities">
     <div class="fa fa-refresh filebrowser-icon" title="Refresh whole directory"
       (click)="displayTree(path, false);" [hidden]="isLoading"></div>
+    <div class="fa fa-spinner fa-spin filebrowser-icon" [hidden]="!isLoading"></div>
     <div class="fa fa-minus-square-o filebrowser-icon" title="Collapse Folders in Explorer" (click)="collapseTree();">
     </div>
     <div class="fa fa-trash-o filebrowser-icon" title="Delete" (click)="showDeleteDialog(selectedNode);"></div>
@@ -45,7 +44,7 @@ Copyright Contributors to the Zowe Project.
   </div>
 
   <!-- Main tree -->
-  <div [hidden]="hideExplorer" style="flex: 1; overflow: hidden; min-height: 0;">
+  <div [hidden]="hideExplorer" class="filebrowser-tree-wrapper">
     <tree-root 
       [treeData]="data"
       (clickEvent)="onNodeClick($event)"

--- a/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/filebrowseruss/filebrowseruss.component.html
@@ -37,8 +37,8 @@ Copyright Contributors to the Zowe Project.
     <div class="fa fa-folder-o filebrowser-icon" title="Create New Folder"
       (click)="showCreateFolderDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
     </div>
-    <div class="fa fa-file-o filebrowser-icon" title="Create New File"
-      (click)="showCreateFileDialog(!selectedNode || (!selectedNode.parent && !selectedNode.directory) ? { 'path' : path } : selectedNode.directory ? selectedNode : selectedNode.parent);">
+    <div class="fa fa-plus filebrowser-icon" title="New File" style="font-size: 14px;"
+      (click)="newFileClick.emit(selectedNode || '')">
     </div>
     <div class="fa fa-eraser filebrowser-icon special-utility" title="Clear Search History"
       (click)="clearSearchHistory();"></div>

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
@@ -33,7 +33,7 @@
 }
 
 .p-tree .p-tree-container {
-  padding: 10px 5px 9px !important;
+  padding: 10px 5px 9px 15px !important;
   font-size: medium !important;
   color: inherit !important;
   overflow: auto !important;

--- a/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/tree/tree.component.css
@@ -17,21 +17,23 @@
   background: transparent !important;
   height: 100% !important;
   width: 100% !important;
-  margin-right: 10px !important;
+  margin: 0 !important;
+  padding: 0 !important;
   color: inherit !important;
+  overflow: visible !important;
 }
 
 .p-tree {
   width: 100% !important;
   height: 100% !important;
-  min-width: 300px !important;
+  min-width: 0 !important;
   background: transparent !important;
   border: 0px !important;
   border: none !important;
 }
 
 .p-tree .p-tree-container {
-  padding: 15px 15px 9px 15px !important;
+  padding: 10px 5px 9px !important;
   font-size: medium !important;
   color: inherit !important;
   overflow: auto !important;

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
@@ -9,9 +9,11 @@
 */
 
 .fileexplorer-browser-module {
-  margin-left: 10px;
-  margin-top: 10px;
-  height: 100%;
+  margin: 0;
+  padding: 8px 0 0 0;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 :host {
@@ -26,7 +28,10 @@
 }
 
 .fileexplorer-global {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  overflow: hidden;
 }
 
 .fileexplorer-tabs {

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
@@ -9,11 +9,12 @@
 */
 
 .fileexplorer-browser-module {
-  margin: 0;
-  padding: 8px 0 0 0;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
+  margin: 0 !important;
+  padding: 8px 0 0 0 !important;
+  flex: 1 !important;
+  min-height: 0 !important;
+  max-height: none !important;
+  overflow: hidden !important;
 }
 
 :host {
@@ -24,7 +25,7 @@
 :host > .mat-tab-group,
 :host .mat-mdc-tab-body-wrapper,
 :host .mat-mdc-tab-body-content {
-  height: 100%;
+  height: 100% !important;
 }
 
 .fileexplorer-global {

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.css
@@ -14,6 +14,17 @@
   height: 100%;
 }
 
+:host {
+  display: block;
+  height: 100%;
+}
+
+:host > .mat-tab-group,
+:host .mat-mdc-tab-body-wrapper,
+:host .mat-mdc-tab-body-content {
+  height: 100%;
+}
+
 .fileexplorer-global {
   height: 100%;
 }

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 -->
 
-<div class="fileexplorer-global" #fileExplorerGlobal>
+<div class="fileexplorer-global" #fileExplorerGlobal style="display: flex; flex-direction: column; height: 100%; overflow: hidden;">
   <nav data-tabs class="fileexplorer-tabs" role="navigation">
     <div class="fileexplorer-tabs-trigger" tabindex="-1">
       <a href="javascript:void(0)" class="bx--tabs-trigger-text" tabindex="-1"></a>

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.html
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.html
@@ -28,7 +28,7 @@ Copyright Contributors to the Zowe Project.
   <div class="fileexplorer-browser-module" [ngStyle]="style">
     <file-browser-uss #ussComponent [hidden]="currentIndex != 0" (nodeClick)="onNodeClick($event)"
       (nodeDblClick)="onNodeDblClick($event)" (openInNewTab)="onOpenInNewTab($event)"
-      (newFolderClick)="onNewFolderClick($event)" (fileUploaded)="onFileUploaded($event)"
+      (newFileClick)="onNewFileClick($event)" (newFolderClick)="onNewFolderClick($event)" (fileUploaded)="onFileUploaded($event)"
       (deleteClick)="onDeleteClick($event)" (ussRenameEvent)="onUSSRenameEvent($event)"
       (copyClick)="onCopyClick($event)" (rightClick)="onRightClick($event)" (pathChanged)="onPathChanged($event)"
       (dataChanged)="onDataChanged($event)" [style]="style" [inputStyle]="inputStyle" [treeStyle]="treeStyle"

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.ts
@@ -147,7 +147,7 @@ export class ZluxFileTreeComponent implements OnInit, OnDestroy {
   @Output() nodeDblClick: EventEmitter<any> = new EventEmitter<any>();
   @Output() newFolderClick: EventEmitter<any> = new EventEmitter<any>();
   @Output() fileUploaded: EventEmitter<any> = new EventEmitter<any>();
-  // @Output() newFileClick: EventEmitter<any> = new EventEmitter<any>();
+  @Output() newFileClick: EventEmitter<any> = new EventEmitter<any>();
   @Output() copyClick: EventEmitter<any> = new EventEmitter<any>();
   @Output() deleteClick: EventEmitter<any> = new EventEmitter<any>();
   @Output() ussRenameEvent: EventEmitter<any> = new EventEmitter<any>();
@@ -291,9 +291,9 @@ export class ZluxFileTreeComponent implements OnInit, OnDestroy {
     this.ussRenameEvent.emit($event);
   }
 
-  // onNewFileClick($event:any){
-  //   this.newFileClick.emit($event);
-  // }
+  onNewFileClick($event:any){
+    this.newFileClick.emit($event);
+  }
 
   onNewFolderClick($event: any) {
     this.newFolderClick.emit($event);

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.ts
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.component.ts
@@ -15,7 +15,7 @@ declare var require: any;
 import {
   Component,
   Input, Output, ViewChild, ViewEncapsulation,
-  ElementRef, ChangeDetectorRef,
+  ElementRef, ChangeDetectorRef, HostBinding,
   EventEmitter, OnInit, OnDestroy, Inject
 } from '@angular/core';
 // import {FileContents} from '../../structures/filecontents';
@@ -51,6 +51,10 @@ import { Angular2InjectionTokens } from '../../../pluginlib/inject-resources';
 
 export class ZluxFileTreeComponent implements OnInit, OnDestroy {
   //componentClass: ComponentClass;
+
+  @HostBinding('style.display') hostDisplay = 'block';
+  @HostBinding('style.height') hostHeight = '100%';
+
   public currentIndex: number;
   public tabs: Array<tab>;
   public showUpArrow: boolean;

--- a/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.module.ts
+++ b/projects/zlux-file-explorer/src/lib/components/zlux-file-tree/zlux-file-tree.module.ts
@@ -33,6 +33,7 @@ import { UploaderService } from "../../services/uploader.service";
 import { CreateDatasetModal } from "../create-dataset-modal/create-dataset-modal.component";
 import { CreateFileModal } from "../create-file-modal/create-file-modal.component";
 import { CreateFolderModal } from "../create-folder-modal/create-folder-modal.component";
+import { CreateMemberModal } from "../create-member-modal/create-member-modal.component";
 import { DatasetPropertiesModal } from "../dataset-properties-modal/dataset-properties-modal.component";
 import { DeleteFileModal } from "../delete-file-modal/delete-file-modal.component";
 import { FileOwnershipModal } from "../file-ownership-modal/file-ownership-modal.component";
@@ -65,6 +66,7 @@ import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
     DeleteFileModal,
     CreateFolderModal,
     CreateFileModal,
+    CreateMemberModal,
     UploadModal,
     TreeComponent,
     CreateDatasetModal

--- a/projects/zlux-file-explorer/src/lib/services/dataset.crud.service.ts
+++ b/projects/zlux-file-explorer/src/lib/services/dataset.crud.service.ts
@@ -27,7 +27,7 @@ export class DatasetCrudService {
 
   private handleErrorObservable (error: Response | any) {
     console.error(error.message || error);
-    return throwError(error.message || error);
+    return throwError(() => error.message || error);
   }
   
   //addfolder
@@ -123,7 +123,7 @@ export class DatasetCrudService {
           // ensure that dataset is recalled, otherwise throw an error
           datasetAttrs =>
             this.utils.isDatasetMigrated(datasetAttrs) ?
-              throwError(new Error('Unable to recall dataset')) : of(datasetAttrs)
+              throwError(() => new Error('Unable to recall dataset')) : of(datasetAttrs)
         )
       );
   }
@@ -132,7 +132,7 @@ export class DatasetCrudService {
     const contentsURI = ZoweZLUX.uriBroker.datasetContentsUri(name);
     return this.http.put(contentsURI, datasetAttributes)
       .pipe(
-        catchError(error => throwError(error)),
+        catchError(error => throwError(() => error)),
         map((res:any) => res)
       );
   }
@@ -144,7 +144,7 @@ export class DatasetCrudService {
     const contentsURI = ZoweZLUX.uriBroker.datasetContentsUri(memberPath);
     return this.http.put(contentsURI, { records: [] })
       .pipe(
-        catchError(error => throwError(error))
+        catchError(error => throwError(() => error))
       );
   }
 }

--- a/projects/zlux-file-explorer/src/lib/services/dataset.crud.service.ts
+++ b/projects/zlux-file-explorer/src/lib/services/dataset.crud.service.ts
@@ -136,6 +136,17 @@ export class DatasetCrudService {
         map((res:any) => res)
       );
   }
+
+  createMember(datasetName: string, memberName: string): Observable<any> {
+    const normalizedDatasetName = datasetName.trim().toUpperCase();
+    const normalizedMemberName = memberName.trim().toUpperCase();
+    const memberPath = `${normalizedDatasetName}(${normalizedMemberName})`;
+    const contentsURI = ZoweZLUX.uriBroker.datasetContentsUri(memberPath);
+    return this.http.put(contentsURI, { records: [] })
+      .pipe(
+        catchError(error => throwError(error))
+      );
+  }
 }
 
 /*


### PR DESCRIPTION
## Proposed changes

This PR adds **Create Member** functionality to the MVS file explorer, along with a **"New File" button** in the USS explorer toolbar, and fixes several bugs in the existing dataset operations. This is the library-side counterpart that enables the editor (PR [zlux-editor#393](https://github.com/zowe/zlux-editor/pull/393)) to provide full dataset save capabilities.

This PR addresses Issue: [MVD-6036](https://github.com/zowe/zlux/issues) — Add Create Dataset Member capability to zlux-file-explorer

This PR depends upon the following PRs: None (this is the base library PR)

---

### New Features

#### 1. Create Member Modal (`CreateMemberModal`)
A new dialog component for creating empty members in Partitioned Datasets:
- **Accessible via right-click** → "Create Member" on any PDS node in the MVS tree
- **Auto-uppercase**: Input is trimmed and uppercased before submission
- **Loading state**: Spinner icon with disabled inputs/button while API call is in progress
- **Error recovery**: On failure, spinner resets so the user can correct the name and retry
- **Contextual "Create Member" visibility**: The menu item is hidden for non-PDS nodes (sequential datasets, VSAM clusters)

#### 2. New File Button in USS Explorer
- Uncommented and wired up the `newFileClick` output event from `ZluxFileTreeComponent`
- Added a `fa-plus` icon button to the USS toolbar that emits `newFileClick` to the parent editor

#### 3. `createMember()` Service Method
Added to `DatasetCrudService`:
```typescript
createMember(datasetName: string, memberName: string): Observable<any>
```
- Normalizes names (trim + uppercase)
- PUTs an empty `{ records: [] }` body to `datasetContentsUri(DSN(MEMBER))` to create the member

---

### Bug Fixes

| # | Fix | File |
|---|-----|------|
| 1 | **`createDatasetDialog` crash on Cancel** — `attributes` was accessed before null check; moved early return guard | `filebrowsermvs.component.ts` |
| 2 | **Error messages showing `[object Object]`** — Added `typeof` check with `JSON.stringify` fallback for all error handlers | `filebrowsermvs.component.ts` |
| 3 | **Deprecated `throwError(value)` calls** — Migrated to `throwError(() => value)` (RxJS 7+ requirement) | `dataset.crud.service.ts` |
| 4 | **Unused imports in `CreateFileModal`** — Removed dead `HttpClient` and `MatSnackBar` imports | `create-file-modal.component.ts` |

---

### UX Improvements

#### Smarter `isPartitionedDataset()` Detection
- Checks `dsorg` metadata **first** (organization string, `isPDSDir`, `isPDSE` flags)
- Falls back to `node.type === 'folder'` only if no metadata exists
- Prevents showing "Create Member" for migrated datasets or VSAM clusters that appear as folders

#### Toolbar Layout Modernization (MVS + USS)
- Replaced `float: right` + `margin-right: 9px` inline styles with **flexbox** layout
- Added `display: flex`, `align-items: center`, `gap: 4px` to `.file-tree-utilities`
- Icons now use consistent sizing (`font-size: 15px`) with proper centering
- Removed inline `style=` attributes from HTML (moved to CSS)

---

### Files Changed

| File | Change |
|------|--------|
| `create-member-modal/` (NEW) | Full component: `.html`, `.ts`, `.scss` |
| `filebrowsermvs.component.ts` | Create Member dialog, `isPartitionedDataset()`, right-click filter, `createDatasetDialog` fix |
| `filebrowsermvs.component.html` | Toolbar cleanup — removed inline styles |
| `filebrowsermvs.component.css` | Flexbox toolbar layout |
| `filebrowseruss.component.html` | Added "New File" button |
| `filebrowseruss.component.css` | Flexbox toolbar layout + icon centering |
| `zlux-file-tree.component.html` | Wired `newFileClick` event from USS component |
| `zlux-file-tree.component.ts` | Uncommented `newFileClick` output + handler |
| `zlux-file-tree.module.ts` | Registered `CreateMemberModal` in module declarations |
| `dataset.crud.service.ts` | Added `createMember()` method, fixed deprecated `throwError` |
| `create-file-modal.component.ts` | Removed unused imports |
| `package.json` / `package-lock.json` | Updated `lodash` 4.17.21 → 4.18.1 |

---

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor the code

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

### Manual Testing Steps:
1. **Create Member via Right-Click**:
   - Search for a PDS (e.g., `USER.*`)
   - Right-click on a PDS folder node → Verify "Create Member" appears in context menu
   - Click "Create Member" → Enter valid member name (e.g., `TEST01`) → Click Create
   - Verify spinner appears, then success snackbar and tree refreshes with new member

2. **Validation**:
   - Enter invalid names: lowercase (auto-uppercased), `123ABC` (starts with number — rejected), `TOOLONGNAME` (>8 chars — rejected)
   - Verify red validation hint appears below the input

3. **Error Handling**:
   - Try creating a member that already exists → Verify meaningful error message (not `[object Object]`)
   - Try creating member in a dataset being deleted → Verify "dataset queued for deletion" message

4. **Context Menu Filtering**:
   - Right-click on a sequential dataset → Verify "Create Member" does NOT appear
   - Right-click on a PDS → Verify "Create Member" DOES appear

5. **Create Dataset Cancel**:
   - Click "+" to create dataset → Press ESC or close dialog → Verify no crash

6. **USS New File Button**:
   - Switch to USS tab → Verify "+" icon appears in toolbar → Click it → Verify new file tab opens

## Further comments

This PR provides the shared library components consumed by [zlux-editor#393](https://github.com/zowe/zlux-editor/pull/393). The editor PR depends on the published version of `@zowe/zlux-angular-file-tree` from this PR.

**Merge order**: This PR (#228) should be merged first, then update the dependency version in PR #393 before merging that.